### PR TITLE
Add functionality to stop and restart processes

### DIFF
--- a/src/provider/error.rs
+++ b/src/provider/error.rs
@@ -44,5 +44,5 @@ pub enum StackableError {
     )]
     MissingConfigMapsError { missing_config_maps: Vec<String> },
     #[error("An object received from Kubernetes didn't contain a required field: {field_name}")]
-    IllegalKubeObject {field_name: String}
+    IllegalKubeObject { field_name: String },
 }

--- a/src/provider/error.rs
+++ b/src/provider/error.rs
@@ -43,4 +43,6 @@ pub enum StackableError {
         "The following config maps were specified in a pod but not found: {missing_config_maps:?}"
     )]
     MissingConfigMapsError { missing_config_maps: Vec<String> },
+    #[error("An object received from Kubernetes didn't contain a required field: {field_name}")]
+    IllegalKubeObject {field_name: String}
 }

--- a/src/provider/error.rs
+++ b/src/provider/error.rs
@@ -43,6 +43,6 @@ pub enum StackableError {
         "The following config maps were specified in a pod but not found: {missing_config_maps:?}"
     )]
     MissingConfigMapsError { missing_config_maps: Vec<String> },
-    #[error("An object received from Kubernetes didn't contain a required field: {field_name}")]
-    IllegalKubeObject { field_name: String },
+    #[error("Object is missing key: {key}")]
+    MissingObjectKey { key: &'static str },
 }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -14,7 +14,7 @@ use log::{debug, error};
 
 use crate::provider::error::StackableError;
 use crate::provider::error::StackableError::{
-    CrdMissing, IllegalKubeObject, KubeError, PodValidationError,
+    CrdMissing, KubeError, MissingObjectKey, PodValidationError,
 };
 use crate::provider::repository::package::Package;
 use crate::provider::states::downloading::Downloading;
@@ -164,8 +164,8 @@ impl Provider for StackableProvider {
         let service_uid = if let Some(uid) = pod.as_kube_pod().metadata.uid.as_ref() {
             uid.to_string()
         } else {
-            return Err(anyhow::Error::new(IllegalKubeObject {
-                field_name: "uid".to_string(),
+            return Err(anyhow::Error::new(MissingObjectKey {
+                key: ".metadata.uid",
             }));
         };
         let parcel_directory = self.parcel_directory.clone();

--- a/src/provider/states/starting.rs
+++ b/src/provider/states/starting.rs
@@ -115,13 +115,10 @@ impl State<PodState> for Starting {
                                 );
                             }
                         }
-                        //pod_state.process_handle = Some(child);
-                        return Transition::next(
-                            self,
-                            Running {
-                                process_handle: Some(child),
-                            },
-                        );
+                        // Store the child handle in the podstate so that later states
+                        // can use it
+                        pod_state.process_handle = Some(child);
+                        return Transition::next(self, Running {});
                     }
                     Err(error) => {
                         let error_message = format!("Failed to start process with error {}", error);

--- a/src/provider/states/stopping.rs
+++ b/src/provider/states/stopping.rs
@@ -17,7 +17,7 @@ impl State<PodState> for Stopping {
         if let Some(child) = &pod_state.process_handle {
             info!(
                 "Received stop command for service {}, stopping process with pid {}",
-                pod_state.service_name, &1
+                pod_state.service_name, child.id()
             );
         }
         Transition::next(self, Stopped)

--- a/src/provider/states/stopping.rs
+++ b/src/provider/states/stopping.rs
@@ -15,10 +15,9 @@ pub struct Stopping;
 impl State<PodState> for Stopping {
     async fn next(self: Box<Self>, pod_state: &mut PodState, _pod: &Pod) -> Transition<PodState> {
         if let Some(child) = &pod_state.process_handle {
-            let pid = child.id();
             info!(
                 "Received stop command for service {}, stopping process with pid {}",
-                pod_state.service_name, pid
+                pod_state.service_name, &1
             );
         }
         Transition::next(self, Stopped)

--- a/src/provider/states/stopping.rs
+++ b/src/provider/states/stopping.rs
@@ -17,7 +17,8 @@ impl State<PodState> for Stopping {
         if let Some(child) = &pod_state.process_handle {
             info!(
                 "Received stop command for service {}, stopping process with pid {}",
-                pod_state.service_name, child.id()
+                pod_state.service_name,
+                child.id()
             );
         }
         Transition::next(self, Stopped)


### PR DESCRIPTION
This enables stopping services by deleting their pod objects and subsequently restarting them by recreating the pod.
This unlocks rolling restart/restart functionality in operators.

Also contains change to add pod-uid to the config directory name.