### PR TITLE
Added setting of pod condition "ready" for state "running"

### DIFF
--- a/src/provider/states.rs
+++ b/src/provider/states.rs
@@ -1,3 +1,7 @@
+use k8s_openapi::api::core::v1::ContainerStatus as KubeContainerStatus;
+use k8s_openapi::api::core::v1::PodCondition as KubePodCondition;
+use kubelet::pod::Phase;
+
 pub(crate) mod creating_config;
 pub(crate) mod creating_service;
 pub(crate) mod downloading;
@@ -21,4 +25,48 @@ macro_rules! fail_fatal {
         log::error!("{:?}", aerr);
         return Transition::Complete(Err(aerr));
     }};
+}
+
+/// Create basic Pod status patch with container status and pod conditions
+pub fn make_status_with_containers_and_condition(
+    phase: Phase,
+    reason: &str,
+    container_statuses: Vec<KubeContainerStatus>,
+    init_container_statuses: Vec<KubeContainerStatus>,
+    pod_conditions: Vec<KubePodCondition>,
+) -> serde_json::Value {
+    serde_json::json!(
+       {
+           "metadata": {
+               "resourceVersion": "",
+           },
+           "status": {
+               "phase": phase,
+               "reason": reason,
+               "containerStatuses": container_statuses,
+               "initContainerStatuses": init_container_statuses,
+               "conditions": pod_conditions
+           }
+       }
+    )
+}
+
+/// Create basic Pod status patch.
+pub fn make_status_with_condition(
+    phase: Phase,
+    reason: &str,
+    pod_conditions: Vec<KubePodCondition>,
+) -> serde_json::Value {
+    serde_json::json!(
+       {
+           "metadata": {
+               "resourceVersion": "",
+           },
+           "status": {
+               "phase": phase,
+               "reason": reason,
+               "conditions": pod_conditions
+           }
+       }
+    )
 }

--- a/src/provider/states.rs
+++ b/src/provider/states.rs
@@ -37,34 +37,11 @@ pub fn make_status_with_containers_and_condition(
 ) -> serde_json::Value {
     serde_json::json!(
        {
-           "metadata": {
-               "resourceVersion": "",
-           },
            "status": {
                "phase": phase,
                "reason": reason,
                "containerStatuses": container_statuses,
                "initContainerStatuses": init_container_statuses,
-               "conditions": pod_conditions
-           }
-       }
-    )
-}
-
-/// Create basic Pod status patch.
-pub fn make_status_with_condition(
-    phase: Phase,
-    reason: &str,
-    pod_conditions: Vec<KubePodCondition>,
-) -> serde_json::Value {
-    serde_json::json!(
-       {
-           "metadata": {
-               "resourceVersion": "",
-           },
-           "status": {
-               "phase": phase,
-               "reason": reason,
                "conditions": pod_conditions
            }
        }

--- a/src/provider/states/starting.rs
+++ b/src/provider/states/starting.rs
@@ -144,7 +144,12 @@ impl State<PodState> for Starting {
                         // Store the child handle in the podstate so that later states
                         // can use it
                         pod_state.process_handle = Some(child);
-                        return Transition::next(self, Running {});
+                        return Transition::next(
+                            self,
+                            Running {
+                                ..Default::default()
+                            },
+                        );
                     }
                     Err(error) => {
                         let error_message = format!("Failed to start process with error {}", error);


### PR DESCRIPTION
Some of our operators use the pod condition "ready" to track when a pod is up and running and trigger subsequent actions.