### PR TITLE
Fix failing build job due to error in nightly workflow.

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Build
         run: ~/.cargo/bin/cargo +nightly build --verbose --release
       - name: Build apt package
-        run: ~/.cargo/bin/cargo deb --manifest-path server/Cargo.toml --no-build
+        run: ~/.cargo/bin/cargo deb --no-build
       - name: Publish apt package
         run: >-
           /usr/bin/curl


### PR DESCRIPTION
The nightly workflow contains a manifest path that only exists for operator projects, this was copied here by accident.