### PR TITLE
Give invocation for running cargo inside a container

### DIFF
--- a/docs/modules/ROOT/pages/installation/building.adoc
+++ b/docs/modules/ROOT/pages/installation/building.adoc
@@ -1,11 +1,16 @@
 = Building from source
 
 Building from source is fairly straightforward if you have the rust toolchain installed, our CI chain tests against the latest stable version at the time the checks are run.
-If you need to install this, generally the recommended way is to use https://rustup.rs/[rustup].
+If you need to install this, generally the recommended way is to use https://rustup.rs/[rustup]. Since `rustup` warns if you already have `rust` installed, you might wish to run within a container image.
 
-After rust is installed simply run
+After rust is installed simply run:
 
     cargo build
+    
+or to use a container image for the toolchain:
+
+    podman run -v `pwd`:/src docker.io/library/rust:latest \
+           sh -c "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y libsystemd-dev && rustup component add rustfmt && cd /src && cargo build"
 
 To create the binary file in _target/debug_.
 


### PR DESCRIPTION
I had trouble getting the "right" version of cargo

Ubuntu 20.04.2 LTS hits https://github.com/emilk/egui/issues/297

Ubuntu 21.10 impish (cargo 1.51), fails (after adding rustfmt too):

```
podman run -v `pwd`:/src ubuntu:impish sh -c "apt update && DEBIAN_FRONTEND=noninteractive apt-get install -y cargo libsystemd-dev libssl-dev pkg-config && cargo --version && cargo install --root / rustfmt && cd /src && cargo build"
```

```
  Downloaded prost-build v0.7.0
   Compiling k8s-csi v0.3.0
   Compiling kubelet v0.7.0 (https://github.com/stackabletech/krustlet.git?branch=stackable_patches_v0.7.0#297fe2c2)
   Compiling zvariant v2.7.0
   Compiling kube v0.48.0
   Compiling oci-distribution v0.6.0 (https://github.com/stackabletech/krustlet.git?branch=stackable_patches_v0.7.0#297fe2c2)
error: failed to run custom build command for `kubelet v0.7.0 (https://github.com/stackabletech/krustlet.git?branch=stackable_patches_v0.7.0#297fe2c2)`

Caused by:
  process didn't exit successfully: `/src/target/debug/build/kubelet-734bfb32a0ef2a9f/build-script-build` (exit code: 1)
  --- stdout
  cargo:rerun-if-changed=proto/pluginregistration/v1/pluginregistration.proto
warning: build failed, waiting for other jobs to finish...
error: build failed
```

## Description

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
