### PR TITLE
Added cargo deny action to run on PR.

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,2 +1,0 @@
-[advisories]
-ignore = ["RUSTSEC-2021-0073", "RUSTSEC-2021-0080"]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -97,7 +97,7 @@ jobs:
           - licenses
           - sources
     steps:
-      - uses: actions/checkout@v2
-      - uses: EmbarkStudios/cargo-deny-action@v1
+      - uses: actions/checkout@v2.3.4
+      - uses: EmbarkStudios/cargo-deny-action@v1.2.6
         with:
           command: check ${{ matrix.checks }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -93,11 +93,9 @@ jobs:
       matrix:
         checks:
           - advisories
-          - bans licenses sources
-
-    # Prevent sudden announcement of a new advisory from failing ci:
-    continue-on-error: ${{ matrix.checks == 'advisories' }}
-
+          - bans
+          - licenses
+          - sources
     steps:
       - uses: actions/checkout@v2
       - uses: EmbarkStudios/cargo-deny-action@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -86,11 +86,20 @@ jobs:
         if: ${{ !steps.check_permissions.outputs.has-permission }}
         run: cargo clippy --all-targets -- -D warnings
 
-  security_audit:
-    name: Run security audit
+  cargo-deny:
+    name: Run cargo deny
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        checks:
+          - advisories
+          - bans licenses sources
+
+    # Prevent sudden announcement of a new advisory from failing ci:
+    continue-on-error: ${{ matrix.checks == 'advisories' }}
+
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: actions-rs/audit-check@v1.2.0
+      - uses: actions/checkout@v2
+      - uses: EmbarkStudios/cargo-deny-action@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          command: check ${{ matrix.checks }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 [[package]]
 name = "krator"
 version = "0.2.0"
-source = "git+https://github.com/stackabletech/krustlet.git?branch=stackable_patches_v0.7.0#1a9b8ea204c2777a07fa4105cae4d9f2f3f5423c"
+source = "git+https://github.com/stackabletech/krustlet.git?branch=stackable_patches_v0.7.0#4d2d697c67d3a243bc1e1ae05f0602aacaa58138"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1324,7 +1324,7 @@ dependencies = [
 [[package]]
 name = "krator-derive"
 version = "0.1.0"
-source = "git+https://github.com/stackabletech/krustlet.git?branch=stackable_patches_v0.7.0#1a9b8ea204c2777a07fa4105cae4d9f2f3f5423c"
+source = "git+https://github.com/stackabletech/krustlet.git?branch=stackable_patches_v0.7.0#4d2d697c67d3a243bc1e1ae05f0602aacaa58138"
 dependencies = [
  "quote",
  "syn",
@@ -1398,7 +1398,7 @@ dependencies = [
 [[package]]
 name = "kubelet"
 version = "0.7.0"
-source = "git+https://github.com/stackabletech/krustlet.git?branch=stackable_patches_v0.7.0#1a9b8ea204c2777a07fa4105cae4d9f2f3f5423c"
+source = "git+https://github.com/stackabletech/krustlet.git?branch=stackable_patches_v0.7.0#4d2d697c67d3a243bc1e1ae05f0602aacaa58138"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1762,7 +1762,7 @@ dependencies = [
 [[package]]
 name = "oci-distribution"
 version = "0.6.0"
-source = "git+https://github.com/stackabletech/krustlet.git?branch=stackable_patches_v0.7.0#1a9b8ea204c2777a07fa4105cae4d9f2f3f5423c"
+source = "git+https://github.com/stackabletech/krustlet.git?branch=stackable_patches_v0.7.0#4d2d697c67d3a243bc1e1ae05f0602aacaa58138"
 dependencies = [
  "anyhow",
  "futures-util",

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,42 @@
+[licenses]
+
+confidence-threshold = 1.0
+copyleft = "deny"
+
+unlicensed = "deny"
+
+# List of explictly allowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-3-Clause",
+    "CC0-1.0",
+    "ISC",
+    "LicenseRef-ring",
+    "LicenseRef-webpki",
+    "MIT",
+    "Zlib"
+]
+
+deny = [
+    "AGPL-3.0"
+]
+
+[[licenses.clarify]]
+name = "ring"
+expression = "LicenseRef-ring"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 },
+]
+
+[[licenses.clarify]]
+name = "webpki"
+expression = "LicenseRef-webpki"
+license-files = [
+    { path = "LICENSE", hash = 0x001c7e6c },
+]
+
+[sources.allow-org]
+github = ["stackabletech"]

--- a/deny.toml
+++ b/deny.toml
@@ -1,6 +1,14 @@
+targets = [
+    { triple = "x86_64-unknown-linux-gnu" },
+    { triple = "aarch64-unknown-linux-gnu" },
+    { triple = "x86_64-unknown-linux-musl" },
+    { triple = "aarch64-apple-darwin" },
+    { triple = "x86_64-apple-darwin" },
+]
+
 [licenses]
 
-confidence-threshold = 1.0
+confidence-threshold = 0.99
 copyleft = "deny"
 
 unlicensed = "deny"

--- a/deny.toml
+++ b/deny.toml
@@ -19,18 +19,25 @@ unlicensed = "deny"
 allow = [
     "Apache-2.0",
     "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
     "BSD-3-Clause",
     "CC0-1.0",
     "ISC",
     "LicenseRef-ring",
     "LicenseRef-webpki",
     "MIT",
+    "Unlicense",
     "Zlib"
 ]
 
 deny = [
     "AGPL-3.0"
 ]
+
+exceptions = [
+    { name = "systemd", allow = ["LGPL-2.1-or-later WITH GCC-exception-2.0"] },
+]
+
 
 [[licenses.clarify]]
 name = "ring"

--- a/deny.toml
+++ b/deny.toml
@@ -35,7 +35,7 @@ deny = [
 ]
 
 exceptions = [
-    { name = "systemd", allow = ["LGPL-2.1-or-later"] },
+    { name = "systemd", allow = ["LGPL-2.1"] },
 ]
 
 

--- a/deny.toml
+++ b/deny.toml
@@ -6,52 +6,60 @@ targets = [
     { triple = "x86_64-apple-darwin" },
 ]
 
+[advisories]
+vulnerability = "warn"
+unmaintained = "allow"
+unsound = "warn"
+yanked = "warn"
+notice = "warn"
+
+[bans]
+multiple-versions = "allow"
+
+# TODO Ban openssl when switched to rustls
+# [[bans.deny]]
+# name = "openssl"
+
 [licenses]
-
-confidence-threshold = 0.99
-copyleft = "deny"
-
 unlicensed = "deny"
-
-# List of explictly allowed licenses
-# See https://spdx.org/licenses/ for list of possible licenses
-# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+copyleft = "deny"
+allow-osi-fsf-free = "neither"
+default = "deny"
+confidence-threshold = 1.0
 allow = [
     "Apache-2.0",
-    "Apache-2.0 WITH LLVM-exception",
     "BSD-2-Clause",
     "BSD-3-Clause",
     "CC0-1.0",
     "ISC",
-    "LicenseRef-ring",
-    "LicenseRef-webpki",
+    "LGPL-2.1 WITH GCC-exception-2.0",
     "MIT",
+    "OpenSSL",
     "Unlicense",
-    "Zlib"
+    "Zlib",
 ]
-
-deny = [
-    "AGPL-3.0"
-]
-
-exceptions = [
-    { name = "systemd", allow = ["LGPL-2.1"] },
-]
-
 
 [[licenses.clarify]]
 name = "ring"
-expression = "LicenseRef-ring"
+version = "*"
+expression = "MIT AND ISC AND OpenSSL"
 license-files = [
     { path = "LICENSE", hash = 0xbd0eed23 },
 ]
 
 [[licenses.clarify]]
 name = "webpki"
-expression = "LicenseRef-webpki"
+version = "*"
+expression = "ISC"
 license-files = [
     { path = "LICENSE", hash = 0x001c7e6c },
 ]
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+# TODO Switch to "tag" when stackable_config is released
+required-git-spec = "branch"
 
 [sources.allow-org]
 github = ["stackabletech"]

--- a/deny.toml
+++ b/deny.toml
@@ -35,7 +35,7 @@ deny = [
 ]
 
 exceptions = [
-    { name = "systemd", allow = ["LGPL-2.1-or-later WITH GCC-exception-2.0"] },
+    { name = "systemd", allow = ["LGPL-2.1-or-later"] },
 ]
 
 


### PR DESCRIPTION
## Description
Currently we run cargo-audit on pull requests as well as once per day.

This only checks for security advisories, but we'd also like to ensure that all our dependencies are licensed under compatible licenses, so we added a cargo deny check on pull request. This also scans for security advisories, so we can remove the audit action on PRs. But we will keep in daily, because this action opens issues on the repository, which is nice.


## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
