### PR TITLE
Restrict permissions of private key file

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,6 +5,7 @@
 :224: https://github.com/stackabletech/agent/pull/224[#224]
 :229: https://github.com/stackabletech/agent/pull/229[#229]
 :234: https://github.com/stackabletech/agent/pull/234[#234]
+:235: https://github.com/stackabletech/agent/pull/235[#235]
 
 === Added
 * `hostIP` and `podIP` added to the pod status ({224}).
@@ -13,6 +14,10 @@
 === Fixed
 * Invalid or unreachable repositories are skipped when searching for
   packages ({229}).
+* Access rights of the private key file restricted to the owner ({235}).
+  The permissions are set when the file is created. On existing
+  installations the permissions must be set manually, e.g. with
+  `chmod 600 /etc/stackable/stackable-agent/secret/agent.key`.
 
 == 0.4.0 - 2021-06-23
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 [[package]]
 name = "krator"
 version = "0.2.0"
-source = "git+https://github.com/stackabletech/krustlet.git?branch=stackable_patches_v0.7.0#297fe2c29207dc0c26233b906de243ca6e17148c"
+source = "git+https://github.com/stackabletech/krustlet.git?branch=stackable_patches_v0.7.0#1a9b8ea204c2777a07fa4105cae4d9f2f3f5423c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1324,7 +1324,7 @@ dependencies = [
 [[package]]
 name = "krator-derive"
 version = "0.1.0"
-source = "git+https://github.com/stackabletech/krustlet.git?branch=stackable_patches_v0.7.0#297fe2c29207dc0c26233b906de243ca6e17148c"
+source = "git+https://github.com/stackabletech/krustlet.git?branch=stackable_patches_v0.7.0#1a9b8ea204c2777a07fa4105cae4d9f2f3f5423c"
 dependencies = [
  "quote",
  "syn",
@@ -1398,7 +1398,7 @@ dependencies = [
 [[package]]
 name = "kubelet"
 version = "0.7.0"
-source = "git+https://github.com/stackabletech/krustlet.git?branch=stackable_patches_v0.7.0#297fe2c29207dc0c26233b906de243ca6e17148c"
+source = "git+https://github.com/stackabletech/krustlet.git?branch=stackable_patches_v0.7.0#1a9b8ea204c2777a07fa4105cae4d9f2f3f5423c"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1762,7 +1762,7 @@ dependencies = [
 [[package]]
 name = "oci-distribution"
 version = "0.6.0"
-source = "git+https://github.com/stackabletech/krustlet.git?branch=stackable_patches_v0.7.0#297fe2c29207dc0c26233b906de243ca6e17148c"
+source = "git+https://github.com/stackabletech/krustlet.git?branch=stackable_patches_v0.7.0#1a9b8ea204c2777a07fa4105cae4d9f2f3f5423c"
 dependencies = [
  "anyhow",
  "futures-util",


### PR DESCRIPTION
Fixes #215 

## Description

The access rights of the private key file are restricted to the owner when it is created. On existing installations this must be done manually.

The fix was actually done in krustlet:
- [stackabletech/krustlet](https://github.com/stackabletech/krustlet/commit/1a9b8ea204c2777a07fa4105cae4d9f2f3f5423c) (Branch: stackable_patches_v0.7.0)
- [krustlet/krustlet](https://github.com/krustlet/krustlet/commit/d6fd025c6ccab77cf726b0f427e0e5c6e97714c1) (Branch: main)

This is not testable in the agent-integration-tests.

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
