### PR TITLE
Ignore RUSTSEC-2021-0080

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,2 +1,2 @@
 [advisories]
-ignore = ["RUSTSEC-2021-0073"]
+ignore = ["RUSTSEC-2021-0073", "RUSTSEC-2021-0080"]


### PR DESCRIPTION
## Description

[RUSTSEC-2021-0080](https://rustsec.org/advisories/RUSTSEC-2021-0080.html) will be ignored until there is a new version of the [tar](https://crates.io/crates/tar) crate with a fix.
There is already a pull request (alexcrichton/tar-rs#258).

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
