### PR TITLE
Validate repository URL eagerly

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -2,6 +2,12 @@
 
 == 0.6.0 - unreleased
 
+:262: https://github.com/stackabletech/agent/pull/262[#262]
+
+=== Changed
+* Lazy validation of repository URLs changed to eager validation
+  ({262}).
+
 == 0.5.0 - 2021-07-26
 
 :224: https://github.com/stackabletech/agent/pull/224[#224]


### PR DESCRIPTION
The validation of the repository URL is already performed when a `StackableRepoProvider` is created and not only when the repository content is requested.

Fixes #197 

## Description

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
