### PR TITLE
Move restart policy to systemd

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,10 +1,9 @@
 = Changelog
 
-:263: https://github.com/stackabletech/agent/pull/263[#263]
-
 == 0.6.0 - unreleased
 
 :262: https://github.com/stackabletech/agent/pull/262[#262]
+:263: https://github.com/stackabletech/agent/pull/263[#263]
 :267: https://github.com/stackabletech/agent/pull/267[#267]
 :270: https://github.com/stackabletech/agent/pull/270[#270]
 :273: https://github.com/stackabletech/agent/pull/273[#273]

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -32,6 +32,9 @@
   systemd manages restarts now and the Stackable agent cannot detect if
   a service is in a restart loop ({263}).
 
+=== Fixed
+* Systemd services in session mode are restarted after a reboot ({263}).
+
 == 0.5.0 - 2021-07-26
 
 :224: https://github.com/stackabletech/agent/pull/224[#224]

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -23,6 +23,13 @@
   but not any longer with versions prior to v1.19 ({267}).
 * Error message improved which is logged if a systemd unit file cannot
   be created ({276}).
+* Handling of service restarts moved from the Stackable agent to
+  systemd.
+
+=== Removed
+* Check removed if a service starts up correctly within 10 seconds.
+  systemd manages restarts now and the Stackable agent cannot detect if
+  a service is in a restart loop.
 
 == 0.5.0 - 2021-07-26
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,5 +1,7 @@
 = Changelog
 
+:263: https://github.com/stackabletech/agent/pull/263[#263]
+
 == 0.6.0 - unreleased
 
 :262: https://github.com/stackabletech/agent/pull/262[#262]
@@ -24,12 +26,12 @@
 * Error message improved which is logged if a systemd unit file cannot
   be created ({276}).
 * Handling of service restarts moved from the Stackable agent to
-  systemd.
+  systemd ({263}).
 
 === Removed
 * Check removed if a service starts up correctly within 10 seconds.
   systemd manages restarts now and the Stackable agent cannot detect if
-  a service is in a restart loop.
+  a service is in a restart loop ({263}).
 
 == 0.5.0 - 2021-07-26
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2834,6 +2834,7 @@ dependencies = [
  "handlebars",
  "hostname",
  "indoc",
+ "json-patch",
  "k8s-openapi",
  "krator",
  "kube",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ krator = { git = "https://github.com/stackabletech/krustlet.git", branch = "stac
 kube = { version= "0.48", default-features = false, features = ["derive", "native-tls"] }
 kubelet = { git = "https://github.com/stackabletech/krustlet.git", branch = "stackable_patches_v0.7.0", default-features = true, features= ["derive", "cli"] } # version = "0.7"
 Inflector = "0.11"
+json-patch = "0.2"
 lazy_static = "1.4"
 log = "0.4"
 multimap = "0.8"

--- a/docs/modules/ROOT/pages/services.adoc
+++ b/docs/modules/ROOT/pages/services.adoc
@@ -15,7 +15,3 @@ A pod which provides a service should never terminate on its own, so the
           command:
             - <service-command>
       restartPolicy: Always
-
-After a container command is executed the agent waits for 10 seconds
-before the container status is set to running. When all containers are
-running, also the pod phase is switched from `Pending` to `Running`.

--- a/src/provider/states/pod/running.rs
+++ b/src/provider/states/pod/running.rs
@@ -77,7 +77,15 @@ impl State<PodState> for Running {
                 let systemd_service = &container_handle.systemd_service;
 
                 match systemd_service.service_state().await {
-                    Ok(ServiceState::Running) => {}
+                    Ok(ServiceState::Created) => {
+                        warn!(
+                            "The unit [{}] of service [{}] was not started. \
+                            This should not happen. Ignoring this state for now.",
+                            systemd_service.file(),
+                            pod_state.service_name
+                        );
+                    }
+                    Ok(ServiceState::Started) => {}
                     Ok(ServiceState::Succeeded) => succeeded_containers
                         .push((container_key.to_owned(), container_handle.to_owned())),
                     Ok(ServiceState::Failed) => failed_containers

--- a/src/provider/states/pod/starting.rs
+++ b/src/provider/states/pod/starting.rs
@@ -73,7 +73,7 @@ async fn start_service_units(
     for (container_key, container_handle) in pod_handle.unwrap_or_default() {
         let systemd_service = &container_handle.systemd_service;
 
-        if systemd_service.service_state().await? == ServiceState::Running {
+        if systemd_service.service_state().await? == ServiceState::Started {
             debug!(
                 "Unit [{}] for service [{}] is already running. Skip startup.",
                 systemd_service.file(),
@@ -125,7 +125,7 @@ async fn await_startup(systemd_service: &SystemdService, duration: Duration) -> 
             systemd_service.file()
         );
 
-        if systemd_service.service_state().await? == ServiceState::Running {
+        if systemd_service.service_state().await? == ServiceState::Started {
             debug!(
                 "Service [{}] still running after [{}] seconds",
                 systemd_service.file(),

--- a/src/provider/states/pod/starting.rs
+++ b/src/provider/states/pod/starting.rs
@@ -4,7 +4,7 @@ use crate::provider::{
         accessor::{restart_policy, RestartPolicy},
         status::patch_container_status,
     },
-    systemdmanager::service::SystemdService,
+    systemdmanager::service::{ServiceState, SystemdService},
     PodHandle, PodState, ProviderState,
 };
 
@@ -73,7 +73,7 @@ async fn start_service_units(
     for (container_key, container_handle) in pod_handle.unwrap_or_default() {
         let systemd_service = &container_handle.systemd_service;
 
-        if systemd_service.is_running().await? {
+        if systemd_service.service_state().await? == ServiceState::Running {
             debug!(
                 "Unit [{}] for service [{}] is already running. Skip startup.",
                 systemd_service.file(),
@@ -125,7 +125,7 @@ async fn await_startup(systemd_service: &SystemdService, duration: Duration) -> 
             systemd_service.file()
         );
 
-        if systemd_service.is_running().await? {
+        if systemd_service.service_state().await? == ServiceState::Running {
             debug!(
                 "Service [{}] still running after [{}] seconds",
                 systemd_service.file(),

--- a/src/provider/systemdmanager/service.rs
+++ b/src/provider/systemdmanager/service.rs
@@ -5,9 +5,8 @@ use super::systemd1_api::{
 use crate::provider::systemdmanager::systemd1_api::ServiceResult;
 use anyhow::anyhow;
 
-/// ServiceState represents a coarse-grained state of the service unit.
-#[derive(Clone, Debug, Eq, PartialEq)]
 /// Represents the state of a service unit object.
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ServiceState {
     /// The service was not started yet.
     Created,

--- a/src/provider/systemdmanager/systemd1_api.rs
+++ b/src/provider/systemdmanager/systemd1_api.rs
@@ -507,6 +507,10 @@ trait Service {
     /// state (see ['ActiveState::Failed`]).
     #[dbus_proxy(property)]
     fn result(&self) -> zbus::Result<ServiceResult>;
+
+    /// Number of restarts
+    #[dbus_proxy(property, name = "NRestarts")]
+    fn nrestarts(&self) -> zbus::Result<u32>;
 }
 
 /// A systemd job object

--- a/src/provider/systemdmanager/systemd1_api.rs
+++ b/src/provider/systemdmanager/systemd1_api.rs
@@ -404,6 +404,20 @@ trait Unit {
     #[dbus_proxy(property)]
     fn active_state(&self) -> zbus::Result<ActiveState>;
 
+    /// SubState encodes states of the same state machine that
+    /// ActiveState covers, but knows more fine-grained states that are
+    /// unit-type-specific. Where ActiveState only covers six high-level
+    /// states, SubState covers possibly many more low-level
+    /// unit-type-specific states that are mapped to the six high-level
+    /// states. Note that multiple low-level states might map to the
+    /// same high-level state, but not vice versa. Not all high-level
+    /// states have low-level counterparts on all unit types. At this
+    /// point the low-level states are not documented here, and are more
+    /// likely to be extended later on than the common high-level
+    /// states.
+    #[dbus_proxy(property)]
+    fn sub_state(&self) -> zbus::Result<String>;
+
     /// Unique ID for a runtime cycle of a unit
     #[dbus_proxy(property, name = "InvocationID")]
     fn invocation_id(&self) -> zbus::Result<InvocationId>;

--- a/src/provider/systemdmanager/systemd1_api.rs
+++ b/src/provider/systemdmanager/systemd1_api.rs
@@ -1,4 +1,7 @@
 //! Binding to the D-Bus interface of systemd
+//!
+//! Further documentation can be found in the
+//! [manual](https://www.freedesktop.org/software/systemd/man/org.freedesktop.systemd1).
 use fmt::Display;
 use inflector::cases::kebabcase;
 use serde::{de::Visitor, Deserialize, Serialize};
@@ -368,6 +371,11 @@ pub enum ActiveState {
 
 impl_tryfrom_ownedvalue_for_enum!(ActiveState);
 
+/// Sub state of a service unit object which is set if the service
+/// terminated successfully but is still active due to the
+/// RemainAfterExit setting.
+pub const SUB_STATE_SERVICE_EXITED: &str = "exited";
+
 /// Unique ID for a runtime cycle of a unit
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct InvocationId(Vec<u8>);
@@ -415,6 +423,9 @@ trait Unit {
     /// point the low-level states are not documented here, and are more
     /// likely to be extended later on than the common high-level
     /// states.
+    ///
+    /// Possible sub states can be found in the source code of systemd:
+    /// https://github.com/systemd/systemd/blob/v249/src/basic/unit-def.h
     #[dbus_proxy(property)]
     fn sub_state(&self) -> zbus::Result<String>;
 

--- a/src/provider/systemdmanager/systemdunit.rs
+++ b/src/provider/systemdmanager/systemdunit.rs
@@ -299,6 +299,10 @@ impl SystemDUnit {
 
         unit.set_restart_option(RestartOption::from(restart_policy(&pod)));
 
+        // Relieve the machine a little bit on restart loops but choose
+        // a moderate value so that tests are not slowed down too much.
+        unit.set_restart_sec_option(2);
+
         // Setting RemainAfterExit to "yes" is necessary to reliably
         // determine the state of the service unit object, see
         // manager::SystemdManager::service_state.
@@ -319,6 +323,13 @@ impl SystemDUnit {
     /// service process exits, is killed, or a timeout is reached.
     fn set_restart_option(&mut self, setting: RestartOption) {
         self.set_property(Section::Service, "Restart", &setting.to_string());
+    }
+
+    /// Configures the time to sleep in seconds before restarting a
+    /// service (as configured with [set_restart_option]). Defaults to
+    /// 100ms.
+    fn set_restart_sec_option(&mut self, seconds: u32) {
+        self.set_property(Section::Service, "RestartSec", &seconds.to_string());
     }
 
     /// Causes systemd to consider the unit to be active if the start

--- a/src/provider/systemdmanager/systemdunit.rs
+++ b/src/provider/systemdmanager/systemdunit.rs
@@ -628,9 +628,13 @@ mod test {
                   runAsUserName: pod-user",
         "stackable.service",
         indoc! {"
+            [Unit]
+            StartLimitIntervalSec=0
+
             [Service]
             RemainAfterExit=yes
             Restart=always
+            RestartSec=2
             TimeoutStopSec=30
             User=pod-user"}
     )]
@@ -664,6 +668,7 @@ mod test {
         indoc! {r#"
             [Unit]
             Description=default-stackable-test-container
+            StartLimitIntervalSec=0
 
             [Service]
             Environment="LOG_DIR=/var/log/default-stackable"
@@ -671,6 +676,7 @@ mod test {
             ExecStart=start.sh arg /etc/default-stackable
             RemainAfterExit=yes
             Restart=always
+            RestartSec=2
             StandardError=journal
             StandardOutput=journal
             TimeoutStopSec=30
@@ -701,11 +707,13 @@ mod test {
         indoc! {r#"
             [Unit]
             Description=default-stackable-test-container
+            StartLimitIntervalSec=0
 
             [Service]
             ExecStart=start.sh
             RemainAfterExit=yes
             Restart=always
+            RestartSec=2
             StandardError=journal
             StandardOutput=journal
             TimeoutStopSec=30
@@ -725,9 +733,13 @@ mod test {
               containers: []",
         "stackable.service",
         indoc! {"
+            [Unit]
+            StartLimitIntervalSec=0
+
             [Service]
             RemainAfterExit=yes
             Restart=always
+            RestartSec=2
             TimeoutStopSec=10"}
     )]
     #[case::set_restart_policy(
@@ -742,9 +754,13 @@ mod test {
               restartPolicy: OnFailure",
         "stackable.service",
         indoc! {"
+            [Unit]
+            StartLimitIntervalSec=0
+
             [Service]
             RemainAfterExit=yes
             Restart=on-failure
+            RestartSec=2
             TimeoutStopSec=30"
         }
     )]

--- a/src/provider/systemdmanager/systemdunit.rs
+++ b/src/provider/systemdmanager/systemdunit.rs
@@ -303,6 +303,10 @@ impl SystemDUnit {
         // a moderate value so that tests are not slowed down too much.
         unit.set_restart_sec_option(2);
 
+        // Adhere to the given restart policy and do not limit the
+        // number of restarts.
+        unit.set_start_limit_interval_sec_option(0);
+
         // Setting RemainAfterExit to "yes" is necessary to reliably
         // determine the state of the service unit object, see
         // manager::SystemdManager::service_state.
@@ -330,6 +334,15 @@ impl SystemDUnit {
     /// 100ms.
     fn set_restart_sec_option(&mut self, seconds: u32) {
         self.set_property(Section::Service, "RestartSec", &seconds.to_string());
+    }
+
+    /// Configures unit start rate limiting. Units which are started too
+    /// often within the given time span are not permitted to start any
+    /// more. The allowed number of restarts can be set with
+    /// "StartLimitBurst". May be set to 0 to disable any kind of rate
+    /// limiting.
+    fn set_start_limit_interval_sec_option(&mut self, seconds: u32) {
+        self.set_property(Section::Unit, "StartLimitIntervalSec", &seconds.to_string());
     }
 
     /// Causes systemd to consider the unit to be active if the start

--- a/src/provider/systemdmanager/systemdunit.rs
+++ b/src/provider/systemdmanager/systemdunit.rs
@@ -227,7 +227,15 @@ impl SystemDUnit {
         }
 
         // This one is mandatory, as otherwise enabling the unit fails
-        unit.set_property(Section::Install, "WantedBy", "multi-user.target");
+        unit.set_property(
+            Section::Install,
+            "WantedBy",
+            if user_mode {
+                "default.target"
+            } else {
+                "multi-user.target"
+            },
+        );
 
         Ok(unit)
     }
@@ -727,7 +735,7 @@ mod test {
             TimeoutStopSec=30
 
             [Install]
-            WantedBy=multi-user.target"#}
+            WantedBy=default.target"#}
     )]
     #[case::set_termination_timeout(
         BusType::System,

--- a/src/provider/systemdmanager/systemdunit.rs
+++ b/src/provider/systemdmanager/systemdunit.rs
@@ -299,9 +299,9 @@ impl SystemDUnit {
 
         unit.set_restart_option(RestartOption::from(restart_policy(&pod)));
 
-        // systemd should not remove the unit on its own when it
-        // terminated successfully, so that the agent can check the
-        // outcome and patch the contaner status accordingly.
+        // Setting RemainAfterExit to "yes" is necessary to reliably
+        // determine the state of the service unit object, see
+        // manager::SystemdManager::service_state.
         unit.set_remain_after_exit_option(Boolean::Yes);
 
         if let Some(user_name) = SystemDUnit::get_user_name_from_pod_security_context(pod)? {

--- a/src/provider/systemdmanager/systemdunit.rs
+++ b/src/provider/systemdmanager/systemdunit.rs
@@ -205,14 +205,6 @@ impl SystemDUnit {
 
         unit.set_property(Section::Service, "TimeoutStopSec", &termination_timeout);
 
-        if let Some(stop_timeout) = pod_spec.termination_grace_period_seconds {
-            unit.set_property(
-                Section::Service,
-                "TimeoutStopSec",
-                stop_timeout.to_string().as_str(),
-            );
-        }
-
         if let Some(user_name) = SystemDUnit::get_user_name_from_pod_security_context(pod)? {
             if !user_mode {
                 unit.set_property(Section::Service, "User", user_name);

--- a/src/provider/systemdmanager/systemdunit.rs
+++ b/src/provider/systemdmanager/systemdunit.rs
@@ -6,6 +6,7 @@ use kubelet::pod::Pod;
 
 use crate::provider::error::StackableError;
 use crate::provider::error::StackableError::PodValidationError;
+use crate::provider::kubernetes::accessor::{restart_policy, RestartPolicy};
 use crate::provider::states::pod::creating_config::CreatingConfig;
 use crate::provider::states::pod::PodState;
 use crate::provider::systemdmanager::manager::UnitTypes;
@@ -37,6 +38,79 @@ lazy_static! {
     // see https://systemd.io/USER_NAMES/
     static ref USER_NAME_PATTERN: Regex =
         Regex::new("^[a-zA-Z_][a-zA-Z0-9_-]{0,30}$").unwrap();
+}
+
+/// Configures whether the service shall be restarted when the service
+/// process exits, is killed, or a timeout is reached.
+///
+/// The service process may be the main service process, but it may also
+/// be one of the processes specified with `ExecStartPre=`,
+/// `ExecStartPost=`, `ExecStop=`, `ExecStopPost=`, or `ExecReload=`.
+/// When the death of the process is a result of systemd operation (e.g.
+/// service stop or restart), the service will not be restarted.
+/// Timeouts include missing the watchdog "keep-alive ping" deadline and
+/// a service start, reload, and stop operation timeouts.
+///
+/// As exceptions to the setting, the service will not be restarted if
+/// the exit code or signal is specified in `RestartPreventExitStatus=`
+/// or the service is stopped with `systemctl stop` or an equivalent
+/// operation. Also, the services will always be restarted if the exit
+/// code or signal is specified in `RestartForceExitStatus=`.
+///
+/// Note that service restart is subject to unit start rate limiting
+/// configured with `StartLimitIntervalSec=` and `StartLimitBurst=`. A
+/// restarted service enters the failed state only after the start
+/// limits are reached.
+///
+/// Setting this to "RestartOption::OnFailure" is the recommended choice
+/// for long-running services, in order to increase reliability by
+/// attempting automatic recovery from errors. For services that shall
+/// be able to terminate on their own choice (and avoid immediate
+/// restarting), "RestartOption::OnAbnormal" is an alternative choice.
+#[derive(Clone, Debug, Display, Eq, PartialEq)]
+#[strum(serialize_all = "kebab-case")]
+pub enum RestartOption {
+    /// The service will be restarted regardless of whether it exited
+    /// cleanly or not, got terminated abnormally by a signal, or hit a
+    /// timeout.
+    Always,
+    /// The service will not be restarted.
+    No,
+    /// The service will be restarted when the process is terminated by
+    /// a signal (including on core dump, excluding the signals
+    /// `SIGHUP`, `SIGINT`, `SIGTERM`, or `SIGPIPE`), when an operation
+    /// times out, or when the watchdog timeout is triggered.
+    OnAbnormal,
+    /// The service will be restarted only if the service process exits
+    /// due to an uncaught signal not specified as a clean exit status.
+    OnAbort,
+    /// The service will be restarted when the process exits with a
+    /// non-zero exit code, is terminated by a signal (including on core
+    /// dump, but excluding the signals `SIGHUP`, `SIGINT`, `SIGTERM`,
+    /// or `SIGPIPE`), when an operation (such as service reload) times
+    /// out, and when the configured watchdog timeout is triggered.
+    OnFailure,
+    /// The service will be restarted only when the service process
+    /// exits cleanly. In this context, a clean exit means any of the
+    /// following:
+    /// - exit code of 0;
+    /// - for types other than Type=oneshot, one of the signals
+    ///   `SIGHUP`, `SIGINT`, `SIGTERM`, or `SIGPIPE`;
+    /// - exit statuses and signals specified in SuccessExitStatus=.
+    OnSuccess,
+    /// The service will be restarted only if the watchdog timeout for
+    /// the service expires.
+    OnWatchdog,
+}
+
+impl From<RestartPolicy> for RestartOption {
+    fn from(restart_policy: RestartPolicy) -> Self {
+        match restart_policy {
+            RestartPolicy::Always => RestartOption::Always,
+            RestartPolicy::OnFailure => RestartOption::OnFailure,
+            RestartPolicy::Never => RestartOption::OnAbnormal,
+        }
+    }
 }
 
 /// A struct that represents an individual systemd unit
@@ -205,6 +279,8 @@ impl SystemDUnit {
 
         unit.set_property(Section::Service, "TimeoutStopSec", &termination_timeout);
 
+        unit.set_restart_option(RestartOption::from(restart_policy(&pod)));
+
         if let Some(user_name) = SystemDUnit::get_user_name_from_pod_security_context(pod)? {
             if !user_mode {
                 unit.set_property(Section::Service, "User", user_name);
@@ -214,6 +290,10 @@ impl SystemDUnit {
         }
 
         Ok(unit)
+    }
+
+    fn set_restart_option(&mut self, setting: RestartOption) {
+        self.set_property(Section::Service, "Restart", &setting.to_string());
     }
 
     fn get_user_name_from_pod_security_context(pod: &Pod) -> Result<Option<&str>, StackableError> {
@@ -494,6 +574,7 @@ mod test {
         "stackable.service",
         indoc! {"
             [Service]
+            Restart=always
             TimeoutStopSec=30
             User=pod-user"}
     )]
@@ -532,6 +613,7 @@ mod test {
             Environment="LOG_DIR=/var/log/default-stackable"
             Environment="LOG_LEVEL=INFO"
             ExecStart=start.sh arg /etc/default-stackable
+            Restart=always
             StandardError=journal
             StandardOutput=journal
             TimeoutStopSec=30
@@ -565,6 +647,7 @@ mod test {
 
             [Service]
             ExecStart=start.sh
+            Restart=always
             StandardError=journal
             StandardOutput=journal
             TimeoutStopSec=30
@@ -585,7 +668,25 @@ mod test {
         "stackable.service",
         indoc! {"
             [Service]
+            Restart=always
             TimeoutStopSec=10"}
+    )]
+    #[case::set_restart_policy(
+        BusType::System,
+        "
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              name: stackable
+            spec:
+              containers: []
+              restartPolicy: OnFailure",
+        "stackable.service",
+        indoc! {"
+            [Service]
+            Restart=on-failure
+            TimeoutStopSec=30"
+        }
     )]
 
     fn create_unit_from_pod(


### PR DESCRIPTION
## Description

Fixes #207
Tested by stackabletech/agent-integration-tests#61

### Changed
* Handling of service restarts moved from the Stackable agent to systemd.

### Removed
* Check removed if a service starts up correctly within 10 seconds. systemd manages restarts now and the Stackable agent cannot detect if a service is in a restart loop.

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
