### PR TITLE
Make compatible with Kubernetes v1.22

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -3,10 +3,14 @@
 == 0.6.0 - unreleased
 
 :262: https://github.com/stackabletech/agent/pull/262[#262]
+:267: https://github.com/stackabletech/agent/pull/267[#267]
 
 === Changed
 * Lazy validation of repository URLs changed to eager validation
   ({262}).
+* `certificates.k8s.io/v1` used instead of `certificates.k8s.io/v1beta1`
+  so that the Stackable Agent is now compatible with Kubernetes v1.22
+  but not any longer with versions prior to v1.19 ({267}).
 
 == 0.5.0 - 2021-07-26
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1315,7 +1315,7 @@ dependencies = [
 [[package]]
 name = "krator"
 version = "0.2.0"
-source = "git+https://github.com/stackabletech/krustlet.git?branch=stackable_patches_v0.7.0#4d2d697c67d3a243bc1e1ae05f0602aacaa58138"
+source = "git+https://github.com/stackabletech/krustlet.git?branch=stackable_patches_v0.7.0#ab5b00ac3997d2dc3b257b18bf17e5d264f41a5e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1335,7 +1335,7 @@ dependencies = [
 [[package]]
 name = "krator-derive"
 version = "0.1.0"
-source = "git+https://github.com/stackabletech/krustlet.git?branch=stackable_patches_v0.7.0#4d2d697c67d3a243bc1e1ae05f0602aacaa58138"
+source = "git+https://github.com/stackabletech/krustlet.git?branch=stackable_patches_v0.7.0#ab5b00ac3997d2dc3b257b18bf17e5d264f41a5e"
 dependencies = [
  "quote",
  "syn",
@@ -1409,7 +1409,7 @@ dependencies = [
 [[package]]
 name = "kubelet"
 version = "0.7.0"
-source = "git+https://github.com/stackabletech/krustlet.git?branch=stackable_patches_v0.7.0#4d2d697c67d3a243bc1e1ae05f0602aacaa58138"
+source = "git+https://github.com/stackabletech/krustlet.git?branch=stackable_patches_v0.7.0#ab5b00ac3997d2dc3b257b18bf17e5d264f41a5e"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1773,7 +1773,7 @@ dependencies = [
 [[package]]
 name = "oci-distribution"
 version = "0.6.0"
-source = "git+https://github.com/stackabletech/krustlet.git?branch=stackable_patches_v0.7.0#4d2d697c67d3a243bc1e1ae05f0602aacaa58138"
+source = "git+https://github.com/stackabletech/krustlet.git?branch=stackable_patches_v0.7.0#ab5b00ac3997d2dc3b257b18bf17e5d264f41a5e"
 dependencies = [
  "anyhow",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ flate2 = "1.0"
 futures-util = "0.3"
 handlebars = "4.1"
 hostname = "0.3"
-k8s-openapi = { version = "0.11", default-features = false, features = ["api", "v1_18"] }
+k8s-openapi = { version = "0.11", default-features = false, features = ["api", "v1_20"] }
 krator = { git = "https://github.com/stackabletech/krustlet.git", branch = "stackable_patches_v0.7.0" } # version = "0.2"
 kube = { version= "0.48", default-features = false, features = ["derive", "native-tls"] }
 kubelet = { git = "https://github.com/stackabletech/krustlet.git", branch = "stackable_patches_v0.7.0", default-features = true, features= ["derive", "cli"] } # version = "0.7"

--- a/docs/modules/ROOT/pages/limitations.adoc
+++ b/docs/modules/ROOT/pages/limitations.adoc
@@ -2,5 +2,6 @@
 
 The Stackable Agent has limitations, some of which are documented here.
 
+* Kubernetes v1.19+ is required.
 * The maximum number of pods supported by the agent is currently hardcoded to 110.
   This restriction can be lifted if the need arises.


### PR DESCRIPTION
## Description

`certificates.k8s.io/v1` used instead of `certificates.k8s.io/v1beta1` so that the Stackable Agent is now compatible with Kubernetes v1.22 but not any longer with versions prior to v1.19.

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
