### PR TITLE
Add check if configured directories are writable

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,6 +5,12 @@
 :262: https://github.com/stackabletech/agent/pull/262[#262]
 :267: https://github.com/stackabletech/agent/pull/267[#267]
 :270: https://github.com/stackabletech/agent/pull/270[#270]
+:273: https://github.com/stackabletech/agent/pull/273[#273]
+
+=== Added
+* Prints self-diagnostic information on startup ({270})
+* Check added on startup if the configured directories exist and are
+  writable by the Stackable agent ({273}).
 
 === Changed
 * Lazy validation of repository URLs changed to eager validation
@@ -12,7 +18,6 @@
 * `certificates.k8s.io/v1` used instead of `certificates.k8s.io/v1beta1`
   so that the Stackable Agent is now compatible with Kubernetes v1.22
   but not any longer with versions prior to v1.19 ({267}).
-* Prints self-diagnostic information on startup ({270})
 
 == 0.5.0 - 2021-07-26
 

--- a/src/bin/stackable-agent.rs
+++ b/src/bin/stackable-agent.rs
@@ -1,13 +1,18 @@
+use std::collections::HashMap;
 use std::env;
 use std::ffi::OsString;
+use std::io::ErrorKind;
+use std::path::PathBuf;
 
 use kubelet::config::{Config, ServerConfig};
 use kubelet::Kubelet;
-use log::{info, warn};
-use stackable_config::ConfigBuilder;
+use log::{error, info};
+use tokio::fs::File;
 
 use stackable_agent::config::AgentConfig;
+use stackable_agent::fsext::check_dir_is_writable;
 use stackable_agent::provider::StackableProvider;
+use stackable_config::{ConfigBuilder, ConfigOption};
 
 mod built_info {
     // The file has been placed there by the build script.
@@ -50,6 +55,9 @@ async fn main() -> anyhow::Result<()> {
         built_info::RUSTC_VERSION,
     );
 
+    check_optional_files(&agent_config).await;
+    check_configured_directories(&agent_config).await;
+
     // Currently the only way to _properly_ configure the Krustlet is via these environment exports,
     // as their config object only offers methods that parse from command line flags (or combinations
     // of those flags with other things).
@@ -73,24 +81,23 @@ async fn main() -> anyhow::Result<()> {
 
     export_env("NODE_LABELS", &node_labels);
 
-    if let Some(cert_file_path) = &agent_config.server_cert_file {
-        export_env("KRUSTLET_CERT_FILE", cert_file_path.to_str().unwrap());
-    } else {
-        warn!("Not exporting server cert file path, as non was specified that could be converted to a String.");
-    }
+    export_env(
+        "KRUSTLET_CERT_FILE",
+        agent_config.server_cert_file.to_str().unwrap(),
+    );
 
-    if let Some(key_file_path) = &agent_config.server_key_file {
-        export_env("KRUSTLET_PRIVATE_KEY_FILE", key_file_path.to_str().unwrap());
-    } else {
-        warn!("Not exporting server key file path, as non was specified that could be converted to a String.");
-    }
+    export_env(
+        "KRUSTLET_PRIVATE_KEY_FILE",
+        agent_config.server_key_file.to_str().unwrap(),
+    );
+
     info!("args: {:?}", env::args());
 
     let server_config = ServerConfig {
         addr: agent_config.server_ip_address,
         port: agent_config.server_port,
-        cert_file: agent_config.server_cert_file.to_owned().unwrap_or_default(),
-        private_key_file: agent_config.server_key_file.to_owned().unwrap_or_default(),
+        cert_file: agent_config.server_cert_file.clone(),
+        private_key_file: agent_config.server_key_file.clone(),
     };
 
     let plugins_directory = agent_config.data_directory.join("plugins");
@@ -138,4 +145,104 @@ fn export_env(var_name: &str, var_value: &str) {
 
 fn notify_bootstrap(message: String) {
     info!("Successfully bootstrapped TLS certificate: {}", message);
+}
+
+/// Checks if the optional files can be opened if they exist. An error
+/// is logged if they cannot be opened.
+async fn check_optional_files(config: &AgentConfig) {
+    for (config_option, file) in [
+        (AgentConfig::SERVER_CERT_FILE, &config.server_cert_file),
+        (AgentConfig::SERVER_KEY_FILE, &config.server_key_file),
+    ] {
+        if file.is_file() {
+            if let Err(error) = File::open(file).await {
+                error!(
+                    "Could not open file [{}] which is specified in \
+                    the configuration option [{}]. {}",
+                    file.to_string_lossy(),
+                    config_option.name,
+                    error
+                );
+            }
+        }
+    }
+}
+
+/// Checks the configured directories if they are writable by the
+/// current process. If this is not the case then errors are logged.
+///
+/// This check is performed for informational purposes only. The process
+/// is intentionally not terminated on failure because there can be
+/// false positives, e.g. if the underlying file system does not support
+/// temporary files which are used for the check.
+///
+/// A successful check also does not guarantee that the process can
+/// write to the directory at a later time, e.g. if permissions are
+/// changed or a quota is hit.
+async fn check_configured_directories(config: &AgentConfig) {
+    for (config_option, directory) in directories_where_write_access_is_required(config).await {
+        let directory = if directory.components().count() == 0 {
+            PathBuf::from(".")
+        } else {
+            directory
+        };
+
+        if let Err(error) = check_dir_is_writable(&directory).await {
+            match error.kind() {
+                ErrorKind::NotFound => error!(
+                    "The directory [{}] specified in the configuration \
+                    option [{}] does not exist.",
+                    directory.to_string_lossy(),
+                    config_option.name
+                ),
+                ErrorKind::PermissionDenied => error!(
+                    "The directory [{}] specified in the configuration \
+                    option [{}] is not writable by the process.",
+                    directory.to_string_lossy(),
+                    config_option.name
+                ),
+                _ => error!(
+                    "An IO error occurred while checking the directory \
+                    [{}] specified in the configuration option [{}]. \
+                    {}",
+                    directory.to_string_lossy(),
+                    config_option.name,
+                    error
+                ),
+            };
+        }
+    }
+}
+
+/// Returns all directories configured in the given `AgentConfig` where
+/// write access is required.
+///
+/// The directories of the certificate and key files are only returned
+/// if they do not already exist.
+async fn directories_where_write_access_is_required(
+    config: &AgentConfig,
+) -> HashMap<&ConfigOption, PathBuf> {
+    let mut dirs = HashMap::new();
+    dirs.insert(
+        &AgentConfig::PACKAGE_DIR,
+        config.parcel_directory.to_owned(),
+    );
+    dirs.insert(&AgentConfig::CONFIG_DIR, config.config_directory.to_owned());
+    dirs.insert(&AgentConfig::LOG_DIR, config.log_directory.to_owned());
+    dirs.insert(&AgentConfig::DATA_DIR, config.data_directory.to_owned());
+
+    if !config.server_cert_file.is_file() {
+        dirs.insert(
+            &AgentConfig::SERVER_CERT_FILE,
+            config.server_cert_file_dir().into(),
+        );
+    }
+    if !config.server_key_file.is_file() {
+        dirs.insert(
+            &AgentConfig::SERVER_KEY_FILE,
+            config.server_key_file_dir().into(),
+        );
+    }
+
+    dirs
 }


### PR DESCRIPTION
## Description

Check added if the following directories are writable:
* config
* data
* log
* package
* directory of the certificate file if the file does not exist
* directory of the key file if the file does not exist

Check added if the certificate and key files are readable if they exist.

Log output if a directory is not writable:
```
[2021-08-26T10:14:04Z ERROR stackable_agent] The directory [/] specified in the configuration option [server-cert-file] is not writable by the process.
```

Log output if an optional file exists but cannot be opened:
```
[2021-08-26T10:11:58Z ERROR stackable_agent] Could not open file [/test] which is specified in the configuration option [server-cert-file]. Permission denied (os error 13)
```

This change is not tested with unit tests because it is mainly about IO, so it does not make sense to try to mock the IO. Furthermore unit tests should not modify the filesystem. It is also not possible to test this change with the integration tests because they only communicate with the agent via the Kubernetes API. So they cannot manipulate the file system on the node and cannot restart the agent.

Closes #45 

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
