### PR TITLE
Create missing directories

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -6,11 +6,13 @@
 :267: https://github.com/stackabletech/agent/pull/267[#267]
 :270: https://github.com/stackabletech/agent/pull/270[#270]
 :273: https://github.com/stackabletech/agent/pull/273[#273]
+:274: https://github.com/stackabletech/agent/pull/274[#274]
 
 === Added
 * Prints self-diagnostic information on startup ({270})
 * Check added on startup if the configured directories exist and are
   writable by the Stackable agent ({273}).
+* Missing directories are created ({274}).
 
 === Changed
 * Lazy validation of repository URLs changed to eager validation


### PR DESCRIPTION
## Description

The following directories are created if they do not exist:
* config
* data
* log
* package
* directory of the certificate file if the file does not exist
* directory of the key file if the file does not exist

Log output if a directory was created:
```
[2021-08-27T07:24:53Z INFO  stackable_agent] Directory [data] created which is specified in the configuration option [data-directory].
```

Log output if an IO error occurred:
```
[2021-08-27T07:28:51Z ERROR stackable_agent] Could not create the directory [/etc/passwd/data] which is specified in the configuration option [data-directory]. Not a directory (os error 20)
[2021-08-27T07:29:23Z ERROR stackable_agent] Could not create the directory [/lib/data] which is specified in the configuration option [data-directory]. Permission denied (os error 13)
```

This change is not tested with unit tests because it is mainly about IO, so it does not make sense to try to mock the IO. Furthermore unit tests should not modify the filesystem. It is also not possible to test this change with the integration tests because they only communicate with the agent via the Kubernetes API. So they cannot manipulate the file system on the node and cannot restart the agent.

Closes #105 

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
