### PR TITLE
Improve error message

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -7,9 +7,10 @@
 :270: https://github.com/stackabletech/agent/pull/270[#270]
 :273: https://github.com/stackabletech/agent/pull/273[#273]
 :274: https://github.com/stackabletech/agent/pull/274[#274]
+:276: https://github.com/stackabletech/agent/pull/276[#276]
 
 === Added
-* Prints self-diagnostic information on startup ({270})
+* Prints self-diagnostic information on startup ({270}).
 * Check added on startup if the configured directories exist and are
   writable by the Stackable agent ({273}).
 * Missing directories are created ({274}).
@@ -20,6 +21,8 @@
 * `certificates.k8s.io/v1` used instead of `certificates.k8s.io/v1beta1`
   so that the Stackable Agent is now compatible with Kubernetes v1.22
   but not any longer with versions prior to v1.19 ({267}).
+* Error message improved which is logged if a systemd unit file cannot
+  be created ({276}).
 
 == 0.5.0 - 2021-07-26
 


### PR DESCRIPTION
## Description

Error message improved which is logged if a systemd unit file cannot be created.

The log output looks like this:
```
[2021-08-27T13:14:26Z ERROR krator::state] Object state machine exited with error. error=Unit file [default-agent-service-integration-test.service] could not be created

    Caused by:
        0: File [/lib/systemd/system/default-agent-service-integration-test.service] could not be created
        1: Read-only file system (os error 30)
```

Fixes #47

## Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
