### PR TITLE
Set annotation featureRestartCount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Check added on startup if the configured directories exist and are
   writable by the Stackable agent ([#273]).
 - Missing directories are created ([#274]).
+- Annotation `featureRestartCount` added to the pods to indicate if the
+  restart count is set properly ([#289]).
 
 ### Changed
 - Lazy validation of repository URLs changed to eager validation
@@ -35,6 +37,7 @@
 [#273]: https://github.com/stackabletech/agent/pull/273
 [#274]: https://github.com/stackabletech/agent/pull/274
 [#276]: https://github.com/stackabletech/agent/pull/276
+[#289]: https://github.com/stackabletech/agent/pull/289
 
 ## 0.5.0 - 2021-07-26
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3895,7 +3895,7 @@ dependencies = [
 [[package]]
 name = "zbus"
 version = "2.0.0-beta.6"
-source = "git+https://gitlab.freedesktop.org/dbus/zbus?rev=0a8a4268be0f844ab4bca429f27766347dc3af58#0a8a4268be0f844ab4bca429f27766347dc3af58"
+source = "git+https://gitlab.freedesktop.org/dbus/zbus?rev=ff08cbbbcd3eead16464012b92e3862d4dcb6f16#ff08cbbbcd3eead16464012b92e3862d4dcb6f16"
 dependencies = [
  "async-broadcast",
  "async-channel",
@@ -3907,6 +3907,7 @@ dependencies = [
  "byteorder",
  "derivative",
  "enumflags2",
+ "event-listener",
  "futures-core",
  "futures-sink",
  "futures-util",
@@ -3914,7 +3915,6 @@ dependencies = [
  "nix 0.21.1",
  "once_cell",
  "rand 0.8.4",
- "scoped-tls",
  "serde",
  "serde_repr",
  "sha1",
@@ -3928,7 +3928,7 @@ dependencies = [
 [[package]]
 name = "zbus_macros"
 version = "2.0.0-beta.6"
-source = "git+https://gitlab.freedesktop.org/dbus/zbus?rev=0a8a4268be0f844ab4bca429f27766347dc3af58#0a8a4268be0f844ab4bca429f27766347dc3af58"
+source = "git+https://gitlab.freedesktop.org/dbus/zbus?rev=ff08cbbbcd3eead16464012b92e3862d4dcb6f16#ff08cbbbcd3eead16464012b92e3862d4dcb6f16"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -3940,7 +3940,7 @@ dependencies = [
 [[package]]
 name = "zbus_names"
 version = "1.0.0"
-source = "git+https://gitlab.freedesktop.org/dbus/zbus?rev=0a8a4268be0f844ab4bca429f27766347dc3af58#0a8a4268be0f844ab4bca429f27766347dc3af58"
+source = "git+https://gitlab.freedesktop.org/dbus/zbus?rev=ff08cbbbcd3eead16464012b92e3862d4dcb6f16#ff08cbbbcd3eead16464012b92e3862d4dcb6f16"
 dependencies = [
  "serde",
  "static_assertions",
@@ -3950,10 +3950,11 @@ dependencies = [
 [[package]]
 name = "zvariant"
 version = "2.8.0"
-source = "git+https://gitlab.freedesktop.org/dbus/zbus?rev=0a8a4268be0f844ab4bca429f27766347dc3af58#0a8a4268be0f844ab4bca429f27766347dc3af58"
+source = "git+https://gitlab.freedesktop.org/dbus/zbus?rev=ff08cbbbcd3eead16464012b92e3862d4dcb6f16#ff08cbbbcd3eead16464012b92e3862d4dcb6f16"
 dependencies = [
  "byteorder",
  "enumflags2",
+ "libc",
  "serde",
  "static_assertions",
  "zvariant_derive",
@@ -3962,7 +3963,7 @@ dependencies = [
 [[package]]
 name = "zvariant_derive"
 version = "2.8.0"
-source = "git+https://gitlab.freedesktop.org/dbus/zbus?rev=0a8a4268be0f844ab4bca429f27766347dc3af58#0a8a4268be0f844ab4bca429f27766347dc3af58"
+source = "git+https://gitlab.freedesktop.org/dbus/zbus?rev=ff08cbbbcd3eead16464012b92e3862d4dcb6f16#ff08cbbbcd3eead16464012b92e3862d4dcb6f16"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,8 @@ tar = "0.4"
 thiserror = "1.0"
 tokio = { version = "1.11", features = ["macros", "rt-multi-thread", "time"] }
 url = "2.2"
-zbus = { git = "https://gitlab.freedesktop.org/dbus/zbus", rev = "0a8a4268be0f844ab4bca429f27766347dc3af58" } # version 2.0.0-beta.6 + merge request !354 (fixes a race condition)
-zvariant = { git = "https://gitlab.freedesktop.org/dbus/zbus", rev = "0a8a4268be0f844ab4bca429f27766347dc3af58" } # version 2.8.0 which is compatible with the zbus version
+zbus = { git = "https://gitlab.freedesktop.org/dbus/zbus", rev = "ff08cbbbcd3eead16464012b92e3862d4dcb6f16" } # version 2.0.0-beta.6 + merge request !354 (fixes a race condition) + commit 6cdfe48cda5e0bf7b0dd8675be7a84439678afa9 (fixes another race condition)
+zvariant = { git = "https://gitlab.freedesktop.org/dbus/zbus", rev = "ff08cbbbcd3eead16464012b92e3862d4dcb6f16" } # version 2.8.0 which is compatible with the zbus version
 
 [dev-dependencies]
 indoc = "1.0"

--- a/docs/modules/ROOT/pages/monitoring/restarts.adoc
+++ b/docs/modules/ROOT/pages/monitoring/restarts.adoc
@@ -1,0 +1,17 @@
+= Restarts
+
+The restart count is stored in the container status if systemd version
+235 or newer is running on the node which is the case for Debian 10 and
+CentOS 8 but not for CentOS 7. The annotation `featureRestartCount`
+indicates whether or not the restart count is set properly.
+
+    $ kubectl get pod <pod-name>
+    NAME         READY   STATUS    RESTARTS   AGE
+    <pod-name>   1/1     Running   4          10m
+
+    $ kubectl describe pod <pod-name>
+    Name:         <pod-name>
+    Annotations:  featureRestartCount: true
+    Containers:
+      <service-name>:
+        Restart Count:  4

--- a/src/provider/systemdmanager/service.rs
+++ b/src/provider/systemdmanager/service.rs
@@ -112,6 +112,9 @@ impl SystemdService {
         Ok(service_state)
     }
 
+    /// Retrieves the current restart count.
+    ///
+    /// The restart counter was introduced in systemd version 235.
     pub async fn restart_count(&self) -> anyhow::Result<u32> {
         self.service_proxy
             .nrestarts()


### PR DESCRIPTION
## Description

The annotation `featureRestartCount` is set to `true` if the restart count in the container status can be set properly. This is the case if systemd version 235 or newer is used. If an older systemd version is used then `featureRestartCount` is set to `false`.

Fixes #284 
Tested by stackabletech/agent-integration-tests#71

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
