### PR TITLE
Change binary location in apt package to be consistent with all other packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,5 +71,5 @@ maintainer-scripts = "packaging/debian/"
 systemd-units = { enable = false }
 assets = [
     ["packaging/config/agent.conf", "etc/stackable/stackable-agent/", "644"],
-    ["target/release/stackable-agent", "opt/stackable-agent/stackable-agent", "755"],
+    ["target/release/stackable-agent", "opt/stackabe/stackable-agent/stackable-agent", "755"],
 ]

--- a/packaging/debian/service
+++ b/packaging/debian/service
@@ -4,7 +4,7 @@ Before=
 After=network.target
 [Service]
 User=root
-ExecStart=/opt/stackable-agent/stackable-agent
+ExecStart=/opt/stackable/stackable-agent/stackable-agent
 Restart=on-abort
 StandardOutput=journal
 StandardError=journal


### PR DESCRIPTION
Currently the agent binary is in different places for the rpm and the apt package:

RPM: /opt/stackable/stackable-agent/stackable-agent
APT: /opt/stackable-agent/stackable-agent

This commit changes to location on APT packages to /opt/stackable/stackable-agent/stackable-agent as well, so that this is consistent for all delivery mechanisms. This also matches the binary location for all Stackable operators.

Fixes #301

## Description

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
