### PR TITLE
Remove systemd units without a corresponding pod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Added
+- Cleanup stage added where systemd units without corresponding pods are
+  removed on startup ([#312]).
+
+[#312]: https://github.com/stackabletech/agent/pull/312
+
 ## [0.6.1] - 2021-09-14
 
 ### Changed

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -5,5 +5,8 @@
 * xref:limitations.adoc[]
 * xref:services.adoc[]
 * xref:jobs.adoc[]
+* Stages
+** xref:stages/overview.adoc[]
+** xref:stages/cleanup.adoc[]
 * Monitoring
 ** xref:monitoring/logs.adoc[]

--- a/docs/modules/ROOT/pages/stages/cleanup.adoc
+++ b/docs/modules/ROOT/pages/stages/cleanup.adoc
@@ -1,0 +1,8 @@
+= Cleanup stage
+
+On startup the systemd units in the `system-stackable` slice are
+compared to the pods assigned to this node. If a systemd unit is as
+expected then it is kept and the Stackable agent will take ownership
+again in a later stage. If there is no corresponding pod or the systemd
+unit differs from the pod specification then it is removed and the
+Stackable agent will create a new systemd unit afterwards.

--- a/docs/modules/ROOT/pages/stages/overview.adoc
+++ b/docs/modules/ROOT/pages/stages/overview.adoc
@@ -1,0 +1,26 @@
+= Overview
+
+When the Stackable Agent starts, it runs through the following stages:
+
+* Check configured directories and files.
+** Check if the optional files can be opened if they exist.
+** Create the directories where write access is required and which do
+   not exist yet.
+** Check the configured directories if they are writable by the current
+   process.
+* Bootstrap the cluster with TLS certificates but only if no existing
+  kubeconfig can be found.
+* Remove all systemd units from a previous run without a corresponding
+  pod (see xref:stages/cleanup.adoc[]).
+* Start the kubelet.
+
+After the kubelet was started, assigned pods run through the following
+stages:
+
+* Download the package from a registered Stackable repository.
+* Unpack the package and install it.
+* Create the configuration files according to the config maps. 
+* Create, start, and enable the systemd units.
+* Monitor the systemd units and patch the pod status accordingly.
+* Stop, disable, and remove the systemd units on termination or when the
+  pod is deleted.

--- a/src/bin/stackable-agent.rs
+++ b/src/bin/stackable-agent.rs
@@ -135,6 +135,8 @@ async fn main() -> anyhow::Result<()> {
     .await
     .expect("Error initializing provider.");
 
+    provider.cleanup(&krustlet_config.node_name).await;
+
     let kubelet = Kubelet::new(provider, kubeconfig, krustlet_config).await?;
     kubelet.start().await
 }

--- a/src/provider/cleanup.rs
+++ b/src/provider/cleanup.rs
@@ -1,0 +1,222 @@
+//! Initial cleanup
+//!
+//! On startup the systemd units in the `system-stackable` slice are compared to the pods assigned
+//! to this node. If a systemd unit is as expected then it is kept and the Stackable Agent will
+//! take ownership again in the `Starting` stage.  If there is no corresponding pod or the systemd
+//! unit differs from the pod specification then it is removed and the Stackable Agent will create
+//! a new systemd unit in the `CreatingService` stage.
+//!
+//! The cleanup stage is implemented as part of the [`StackableProvider`] because the expected
+//! content of a systemd unit file can only be determined with the directories configured in the
+//! provider.
+//!
+//! The cleanup code resides in a separate module because the amount of code justifies it and the
+//! log output is more meaningful. It makes it clearer whether a systemd unit is removed in the
+//! cleanup stage or in the normal process.
+use std::collections::HashMap;
+
+use anyhow::Context;
+use k8s_openapi::api::core::v1::Pod as KubePod;
+use kube::api::{ListParams, Meta, ObjectList};
+use kube::Api;
+use kubelet::pod::Pod;
+use kubelet::provider::Provider;
+use log::{debug, error, info, warn};
+use tokio::fs::{read_to_string, remove_file};
+
+use super::systemdmanager::systemdunit::SystemDUnit;
+use super::systemdmanager::systemdunit::STACKABLE_SLICE;
+use super::StackableProvider;
+
+impl StackableProvider {
+    /// Removes systemd units without corresponding pods.
+    ///
+    /// The systemd units in the `system-stackable` slice are compared with the pods assigned to
+    /// this node and all units without corresponding pods or which differ from the pod
+    /// specifications are removed.
+    pub async fn cleanup(&self, node_name: &str) {
+        let systemd_manager = &self.shared.systemd_manager;
+
+        if let Err(error) = systemd_manager.reload().await {
+            error!(
+                "Skipping the cleanup stage because the systemd daemon reload failed. {}",
+                error
+            );
+            return;
+        }
+
+        let units_in_slice = match systemd_manager.slice_content(STACKABLE_SLICE).await {
+            Ok(units_in_slice) => units_in_slice,
+            Err(error) => {
+                debug!(
+                    "Skipping the cleanup stage because no systemd units were found in the slice \
+                    [{}]. {}",
+                    STACKABLE_SLICE, error
+                );
+                return;
+            }
+        };
+
+        let pods = match self.assigned_pods(node_name).await {
+            Ok(pods) => pods.items,
+            Err(error) => {
+                error!(
+                    "The assigned pods could not be retrieved. All systemd units in the slice [{}] \
+                    will be removed. {}",
+                    STACKABLE_SLICE, error
+                );
+                Vec::new()
+            }
+        };
+
+        let mut expected_units = HashMap::new();
+        for pod in pods {
+            match self.units_from_pod(&pod).await {
+                Ok(units) => expected_units.extend(units.into_iter()),
+                Err(error) => warn!(
+                    "Systemd units could not be generated for pod [{}/{}]. {}",
+                    pod.namespace().unwrap_or_else(|| String::from("default")),
+                    pod.name(),
+                    error
+                ),
+            }
+        }
+
+        for unit_name in &units_in_slice {
+            let delete = match expected_units.get(unit_name) {
+                Some(expected_content) => match self.unit_file_content(unit_name).await {
+                    Ok(Some(content)) if &content == expected_content => {
+                        info!(
+                            "The systemd unit [{}] will be kept because a corresponding pod \
+                            exists.",
+                            unit_name
+                        );
+                        false
+                    }
+                    Ok(Some(content)) => {
+                        info!(
+                            "The systemd unit [{}] will be removed because it differs from the \
+                            corresponding pod specification.\n\
+                            expected content:\n\
+                            {}\n\n\
+                            actual content:\n\
+                            {}",
+                            unit_name, expected_content, content
+                        );
+                        true
+                    }
+                    Ok(None) => {
+                        info!(
+                            "The systemd unit [{}] will be removed because its file path could not \
+                            be determined.",
+                            unit_name
+                        );
+                        true
+                    }
+                    Err(error) => {
+                        warn!(
+                            "The systemd unit [{}] will be removed because the file content could \
+                            not be retrieved. {}",
+                            unit_name, error
+                        );
+                        true
+                    }
+                },
+                None => {
+                    info!(
+                        "The systemd unit [{}] will be removed because no corresponding pod \
+                        exists.",
+                        unit_name
+                    );
+                    true
+                }
+            };
+
+            if delete {
+                self.remove_unit(unit_name).await;
+            };
+        }
+    }
+
+    /// Returns a list of all pods assigned to the given node.
+    async fn assigned_pods(&self, node_name: &str) -> anyhow::Result<ObjectList<KubePod>> {
+        let client = &self.shared.client;
+
+        let api: Api<KubePod> = Api::all(client.to_owned());
+        let lp = ListParams::default().fields(&format!("spec.nodeName={}", node_name));
+        api.list(&lp).await.with_context(|| {
+            format!(
+                "The pods assigned to this node (nodeName = [{}]) could not be retrieved.",
+                node_name
+            )
+        })
+    }
+
+    /// Creates the systemd unit files for the given pod in memory.
+    ///
+    /// A mapping from systemd unit file names to the file content is returned.
+    async fn units_from_pod(&self, kubepod: &KubePod) -> anyhow::Result<HashMap<String, String>> {
+        let systemd_manager = &self.shared.systemd_manager;
+
+        let mut units = HashMap::new();
+        let pod = Pod::from(kubepod.to_owned());
+        let pod_state = self.initialize_pod_state(&pod).await?;
+
+        for container in pod.containers() {
+            let unit = SystemDUnit::new(
+                systemd_manager.is_user_mode(),
+                &pod_state,
+                &self.shared.kubeconfig_path,
+                &pod,
+                &container,
+            )?;
+            units.insert(unit.get_name(), unit.get_unit_file_content());
+        }
+
+        Ok(units)
+    }
+
+    /// Returns the content of the given systemd unit file.
+    async fn unit_file_content(&self, unit_name: &str) -> anyhow::Result<Option<String>> {
+        let systemd_manager = &self.shared.systemd_manager;
+
+        let file_path_result = systemd_manager
+            .fragment_path(unit_name)
+            .await
+            .with_context(|| {
+                format!(
+                    "The file path of the unit [{}] could not be determined.",
+                    unit_name
+                )
+            });
+
+        match file_path_result {
+            Ok(Some(file_path)) => {
+                let file_content = read_to_string(&file_path)
+                    .await
+                    .with_context(|| format!("The file [{}] could not be read.", file_path))?;
+                Ok(Some(file_content))
+            }
+            Ok(None) => Ok(None),
+            Err(error) => Err(error),
+        }
+    }
+
+    /// Stops, disables and removes the given systemd unit.
+    async fn remove_unit(&self, unit_name: &str) {
+        let systemd_manager = &self.shared.systemd_manager;
+
+        if let Err(error) = systemd_manager.stop(unit_name).await {
+            warn!("{}", error);
+        }
+        if let Err(error) = systemd_manager.disable(unit_name).await {
+            warn!("{}", error);
+        }
+        if let Ok(Some(file_path)) = systemd_manager.fragment_path(unit_name).await {
+            debug!("Removing file [{}].", file_path);
+            if let Err(error) = remove_file(file_path).await {
+                warn!("{}", error);
+            }
+        }
+    }
+}

--- a/src/provider/systemdmanager/systemd1_api.rs
+++ b/src/provider/systemdmanager/systemd1_api.rs
@@ -407,6 +407,12 @@ impl Display for InvocationId {
     interface = "org.freedesktop.systemd1.Unit"
 )]
 trait Unit {
+    /// `RequiredBy` contains an array which encodes the inverse
+    /// dependencies (where this applies) as configured in the unit file
+    /// or determined automatically.
+    #[dbus_proxy(property)]
+    fn required_by(&self) -> zbus::Result<Vec<String>>;
+
     /// The active state (i.e. whether the unit is currently started or
     /// not)
     #[dbus_proxy(property)]
@@ -425,9 +431,14 @@ trait Unit {
     /// states.
     ///
     /// Possible sub states can be found in the source code of systemd:
-    /// https://github.com/systemd/systemd/blob/v249/src/basic/unit-def.h
+    /// <https://github.com/systemd/systemd/blob/v249/src/basic/unit-def.h>
     #[dbus_proxy(property)]
     fn sub_state(&self) -> zbus::Result<String>;
+
+    /// `FragmentPath` contains the unit file path this unit was read
+    /// from, if there is one (if not, it contains the empty string).
+    #[dbus_proxy(property)]
+    fn fragment_path(&self) -> zbus::Result<String>;
 
     /// Unique ID for a runtime cycle of a unit
     #[dbus_proxy(property, name = "InvocationID")]


### PR DESCRIPTION
## Description

On startup the systemd units in the `system-stackable` slice are compared to the pods assigned to this node. If a systemd unit is as expected then it is kept and the Stackable Agent will take ownership again in a later stage. If there is no corresponding pod or the systemd unit differs from the pod specification then it is removed and the Stackable Agent will create a new systemd unit afterwards.

Closes #180 

## Test

It is not possible to test this change with the [agent-integration-tests](https://github.com/stackabletech/agent-integration-tests) because systemd units must be prepared and the Stackable Agent must be started afterwards, which is not possible over the Kubernetes API. Therefore it must be tested manually.

The following script can be used for manual testing:

```sh
#!/bin/sh

setup_stackable_repository() {
echo Setup Stackable repository

echo -n "
apiVersion: apiextensions.k8s.io/v1
kind: CustomResourceDefinition
metadata:
  name: repositories.stable.stackable.de
spec:
  group: stable.stackable.de
  versions:
    - name: v1
      served: true
      storage: true
      schema:
        openAPIV3Schema:
          type: object
          properties:
            spec:
              type: object
              properties:
                repo_type:
                  type: string
                properties:
                  type: object
                  additionalProperties:
                    type: string
  scope: Namespaced
  names:
    plural: repositories
    singular: repository
    kind: Repository
    shortNames:
    - repo
" | kubectl apply -f -

echo -n "
apiVersion: stable.stackable.de/v1
kind: Repository
metadata:
  name: integration-test-repository
  namespace: default
spec:
  repo_type: StackableRepo
  properties:
    url: https://raw.githubusercontent.com/stackabletech/integration-test-repo/main/
" | kubectl apply -f -
}

setup_unit_with_pod() {
echo Setup unit with pod

echo -n "[Unit]
Description=default-cleanup-test-ok-noop-service
StartLimitIntervalSec=0

[Service]
Environment=\"KUBECONFIG=/root/.kube/config\"
ExecStart=/opt/stackable/packages/noop-service-1.0.0/noop-service-1.0.0/start.sh
RemainAfterExit=no
Restart=always
RestartSec=2
Slice=system-stackable.slice
StandardError=journal
StandardOutput=journal
TimeoutStopSec=30

[Install]
WantedBy=multi-user.target" > /lib/systemd/system/default-cleanup-test-ok-noop-service.service

systemctl daemon-reload
systemctl enable default-cleanup-test-ok-noop-service.service
systemctl start default-cleanup-test-ok-noop-service.service

echo "
apiVersion: v1
kind: Pod
metadata:
  name: cleanup-test-ok
spec:
  containers:
    - name: noop-service
      image: noop-service:1.0.0
      command:
        - noop-service-1.0.0/start.sh
  nodeName: localhost
  nodeSelector:
    kubernetes.io/arch: stackable-linux
  tolerations:
    - key: kubernetes.io/arch
      operator: Equal
      value: stackable-linux
" | kubectl apply -f -
}

setup_unit_without_pod() {
echo Setup unit without pod

echo -n "[Unit]
Description=default-cleanup-test-no-pod-noop-service
StartLimitIntervalSec=0

[Service]
Environment=\"KUBECONFIG=/root/.kube/config\"
ExecStart=/opt/stackable/packages/noop-service-1.0.0/noop-service-1.0.0/start.sh
RemainAfterExit=no
Restart=always
RestartSec=2
Slice=system-stackable.slice
StandardError=journal
StandardOutput=journal
TimeoutStopSec=30

[Install]
WantedBy=multi-user.target" > /lib/systemd/system/default-cleanup-test-no-pod-noop-service.service

systemctl daemon-reload
systemctl enable default-cleanup-test-no-pod-noop-service.service
systemctl start default-cleanup-test-no-pod-noop-service.service
}

setup_unit_with_unexpected_content() {
echo Setup unit with pod

echo -n "[Unit]
Description=You did not expect this, did you?

[Service]
ExecStart=/opt/stackable/packages/noop-service-1.0.0/noop-service-1.0.0/start.sh
Slice=system-stackable.slice

[Install]
WantedBy=multi-user.target" > /lib/systemd/system/default-cleanup-test-unexpected-content-noop-service.service

systemctl daemon-reload
systemctl enable default-cleanup-test-unexpected-content-noop-service.service
systemctl start default-cleanup-test-unexpected-content-noop-service.service

echo "
apiVersion: v1
kind: Pod
metadata:
  name: cleanup-test-unexpected-content
spec:
  containers:
    - name: noop-service
      image: noop-service:1.0.0
      command:
        - noop-service-1.0.0/start.sh
  nodeName: localhost
  nodeSelector:
    kubernetes.io/arch: stackable-linux
  tolerations:
    - key: kubernetes.io/arch
      operator: Equal
      value: stackable-linux
" | kubectl apply -f -
}

setup_unit_with_terminating_pod() {
echo Setup unit with terminating pod

echo -n "[Unit]
Description=default-cleanup-test-terminating-noop-service
StartLimitIntervalSec=0

[Service]
Environment=\"KUBECONFIG=/root/.kube/config\"
ExecStart=/opt/stackable/packages/noop-service-1.0.0/noop-service-1.0.0/start.sh
RemainAfterExit=no
Restart=always
RestartSec=2
Slice=system-stackable.slice
StandardError=journal
StandardOutput=journal
TimeoutStopSec=30

[Install]
WantedBy=multi-user.target" > /lib/systemd/system/default-cleanup-test-terminating-noop-service.service

systemctl daemon-reload
systemctl enable default-cleanup-test-terminating-noop-service.service
systemctl start default-cleanup-test-terminating-noop-service.service

echo "
apiVersion: v1
kind: Pod
metadata:
  name: cleanup-test-terminating
spec:
  containers:
    - name: noop-service
      image: noop-service:1.0.0
      command:
        - noop-service-1.0.0/start.sh
  nodeName: localhost
  nodeSelector:
    kubernetes.io/arch: stackable-linux
  tolerations:
    - key: kubernetes.io/arch
      operator: Equal
      value: stackable-linux
" | kubectl apply -f -

kubectl delete pod cleanup-test-terminating &
}

setup_stackable_repository
setup_unit_with_pod
setup_unit_without_pod
setup_unit_with_unexpected_content
setup_unit_with_terminating_pod
```

The log output of the Stackable Agent should be:

```
[2021-09-24T11:26:39Z INFO  stackable_agent::provider::cleanup] The systemd unit [default-cleanup-test-unexpected-content-noop-service.service] will be removed because it differs from the corresponding pod specification.
    expected content:
    [Unit]
    Description=default-cleanup-test-unexpected-content-noop-service
    StartLimitIntervalSec=0

    [Service]
    Environment="KUBECONFIG=/root/.kube/config"
    ExecStart=/opt/stackable/packages/noop-service-1.0.0/noop-service-1.0.0/start.sh
    RemainAfterExit=no
    Restart=always
    RestartSec=2
    Slice=system-stackable.slice
    StandardError=journal
    StandardOutput=journal
    TimeoutStopSec=30

    [Install]
    WantedBy=multi-user.target

    actual content:
    [Unit]
    Description=You did not expect this, did you?

    [Service]
    ExecStart=/opt/stackable/packages/noop-service-1.0.0/noop-service-1.0.0/start.sh
    Slice=system-stackable.slice

    [Install]
    WantedBy=multi-user.target
[2021-09-24T11:26:39Z INFO  stackable_agent::provider::cleanup] The systemd unit [default-cleanup-test-terminating-noop-service.service] will be removed because the corresponding pod is terminating.
[2021-09-24T11:26:39Z INFO  stackable_agent::provider::cleanup] The systemd unit [default-cleanup-test-ok-noop-service.service] will be kept because a corresponding pod exists.
[2021-09-24T11:26:39Z INFO  stackable_agent::provider::cleanup] The systemd unit [default-cleanup-test-no-pod-noop-service.service] will be removed because no corresponding pod exists.
[2021-09-24T11:26:39Z INFO  warp::server] TlsServer::run; addr=127.0.0.1:3000
[2021-09-24T11:26:39Z INFO  warp::server] listening on https://127.0.0.1:3000
[2021-09-24T11:26:39Z INFO  krator::runtime] Got a watch restart. Resyncing queue...
[2021-09-24T11:26:39Z INFO  krator::runtime] Finished resync of objects.
[2021-09-24T11:26:39Z INFO  stackable_agent::provider::states::pod::downloading] Looking for package: noop-service:1.0.0 in known repositories
[2021-09-24T11:26:39Z INFO  stackable_agent::provider::states::pod::downloading] Package noop-service:1.0.0 has already been downloaded to "/opt/stackable/packages/_download", continuing with installation
[2021-09-24T11:26:39Z INFO  stackable_agent::provider::states::pod::downloading] Looking for package: noop-service:1.0.0 in known repositories
[2021-09-24T11:26:39Z INFO  stackable_agent::provider::states::pod::downloading] Package noop-service:1.0.0 has already been downloaded to "/opt/stackable/packages/_download", continuing with installation
[2021-09-24T11:26:39Z INFO  stackable_agent::provider::states::pod::installing] Package noop-service:1.0.0 has already been installed
[2021-09-24T11:26:39Z INFO  stackable_agent::provider::states::pod::installing] Package noop-service:1.0.0 has already been installed
[2021-09-24T11:26:39Z INFO  stackable_agent::provider::states::pod::creating_service] Creating service unit for service default-cleanup-test-ok
[2021-09-24T11:26:39Z INFO  stackable_agent::provider::states::pod::creating_service] Creating service unit for service default-cleanup-test-unexpected-content
[2021-09-24T11:26:39Z INFO  stackable_agent::provider::states::pod::starting] Starting systemd unit [default-cleanup-test-unexpected-content-noop-service.service]
[2021-09-24T11:26:39Z INFO  stackable_agent::provider::states::pod::starting] Enabling systemd unit [default-cleanup-test-unexpected-content-noop-service.service]
[2021-09-24T11:26:40Z INFO  stackable_agent::provider::states::pod::terminated] Pod default-cleanup-test-terminating was terminated
```

## Leftover

The implementation of `SystemDUnit` was adapted as far as necessary but a complete refactoring would be required. This will be done in #244.

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
