### PR TITLE
Changes the node object which is created by the agent in Kubernetes to report the Stackable Agent version, not the Krustlet version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 [#312]: https://github.com/stackabletech/agent/pull/312
 
+### Changed
+- Changed the version reported by the Stackable Agent in `nodeInfo.kubeletVersion` of the `Node` object in Kubernetes 
+  from the version of the Krustlet library to the Stackable Agent version ([#315]).
+
+[#315]: https://github.com/stackabletech/agent/pull/315
+
 ## [0.6.1] - 2021-09-14
 
 ### Changed

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -50,6 +50,11 @@ mod repository;
 mod states;
 pub mod systemdmanager;
 
+mod built_info {
+    // The file has been placed there by the build script.
+    include!(concat!(env!("OUT_DIR"), "/built.rs"));
+}
+
 /// Provider-level state shared between all pods
 #[derive(Clone)]
 pub struct ProviderState {
@@ -240,6 +245,7 @@ impl Provider for StackableProvider {
     async fn node(&self, builder: &mut Builder) -> anyhow::Result<()> {
         builder.set_architecture(Self::ARCH);
         builder.set_pod_cidr(&self.pod_cidr);
+        builder.set_kubelet_version(built_info::PKG_VERSION);
         builder.add_taint("NoSchedule", "kubernetes.io/arch", Self::ARCH);
         builder.add_taint("NoExecute", "kubernetes.io/arch", Self::ARCH);
         Ok(())


### PR DESCRIPTION
Changes the node object which is created by the agent in Kubernetes to report the Stackable Agent version, not the Krustlet version

fixes #264 

## Description

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
