### PR TITLE
Added improved error handling around downloading and installing packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Changed the version reported by the Stackable Agent in `nodeInfo.kubeletVersion` of the `Node` object in Kubernetes
   from the version of the Krustlet library to the Stackable Agent version ([#315]).
 - Restart agent on all crashes ([#318]).
+- Agent will now request content_type "application/gzip" in package downloads and reject responses with content_type 
+  that is not one of either "application/gzip", "application/tgz" or "application/x-gzip" ([#319])
 
 ### Fixed
 - Agent deletes directories from failed install attempts ([#319])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,17 @@
   removed on startup ([#312]).
 
 ### Changed
+- Changed the version reported by the Stackable Agent in `nodeInfo.kubeletVersion` of the `Node` object in Kubernetes
+  from the version of the Krustlet library to the Stackable Agent version ([#315]).
 - Restart agent on all crashes ([#318]).
 
+### Fixed
+- Agent deletes directories from failed install attempts ([#319])
+
 [#312]: https://github.com/stackabletech/agent/pull/312
-[#318]: https://github.com/stackabletech/agent/pull/318
-
-### Changed
-- Changed the version reported by the Stackable Agent in `nodeInfo.kubeletVersion` of the `Node` object in Kubernetes 
-  from the version of the Krustlet library to the Stackable Agent version ([#315]).
-
 [#315]: https://github.com/stackabletech/agent/pull/315
+[#318]: https://github.com/stackabletech/agent/pull/318
+[#319]: https://github.com/stackabletech/agent/pull/319
 
 ## [0.6.1] - 2021-09-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,16 @@
 - Changed the version reported by the Stackable Agent in `nodeInfo.kubeletVersion` of the `Node` object in Kubernetes
   from the version of the Krustlet library to the Stackable Agent version ([#315]).
 - Restart agent on all crashes ([#318]).
-- Agent will now request content_type "application/gzip" in package downloads and reject responses with content_type 
-  that is not one of either "application/gzip", "application/tgz" or "application/x-gzip" ([#319])
+- Agent will now request content type "application/gzip" in package downloads and reject responses with content type
+  that is not one of either "application/gzip", "application/tgz" or "application/x-gzip" ([#326])
 
 ### Fixed
-- Agent deletes directories from failed install attempts ([#319])
+- Agent deletes directories from failed install attempts ([#326])
 
 [#312]: https://github.com/stackabletech/agent/pull/312
 [#315]: https://github.com/stackabletech/agent/pull/315
 [#318]: https://github.com/stackabletech/agent/pull/318
-[#319]: https://github.com/stackabletech/agent/pull/319
+[#326]: https://github.com/stackabletech/agent/pull/326
 
 ## [0.6.1] - 2021-09-14
 

--- a/src/provider/error.rs
+++ b/src/provider/error.rs
@@ -3,6 +3,7 @@ use k8s_openapi::url;
 use thiserror::Error;
 
 use crate::provider::repository::package::Package;
+use reqwest::Url;
 use std::ffi::OsString;
 
 #[derive(Error, Debug)]
@@ -21,6 +22,12 @@ pub enum StackableError {
     KubeError {
         #[from]
         source: kube::Error,
+    },
+    #[error("An error has ocurred when trying to download [{package}] from [{download_link}]: {errormessage}")]
+    PackageDownloadError {
+        package: Package,
+        download_link: Url,
+        errormessage: String,
     },
     #[error(transparent)]
     TemplateRenderError(#[from] RenderError),

--- a/src/provider/repository/stackablerepository.rs
+++ b/src/provider/repository/stackablerepository.rs
@@ -18,6 +18,10 @@ use reqwest::{Client, StatusCode};
 use serde::{Deserialize, Serialize};
 use url::Url;
 
+// These are the default content_types that we have seen in the wild
+// of these only 'application/gzip' is valid according to
+// https://www.iana.org/assignments/media-types/media-types.xhtml but our own
+// Nexus uses the other two, so we cannot really complain
 lazy_static! {
     static ref DEFAULT_ALLOWED_CONTENT_TYPES: Vec<&'static str> =
         vec!["application/gzip", "application/tgz", "application/x-gzip"];
@@ -141,7 +145,8 @@ impl StackableRepoProvider {
             .await
         {
             Ok(response) if response.status().is_success() => {
-                // The request was successful, but just to be safe we'll still check the content_type
+                // The request was successful, but just to be safe we'll still check the content_type, 
+                // since the webserver is free to ignore the requested content_type
                 if let Some(content_type) = response.headers().get(CONTENT_TYPE) {
                     let content_type = content_type.to_str().map_err(|error| PackageDownloadError {
                         package: package.clone(),

--- a/src/provider/repository/stackablerepository.rs
+++ b/src/provider/repository/stackablerepository.rs
@@ -11,7 +11,6 @@ use crate::provider::error::StackableError::{PackageDownloadError, PackageNotFou
 use crate::provider::repository::package::Package;
 use crate::provider::repository::repository_spec::Repository;
 use kube::api::Meta;
-use lazy_static::lazy_static;
 use log::{debug, trace, warn};
 use reqwest::header::{ACCEPT, CONTENT_TYPE};
 use reqwest::{Client, StatusCode};
@@ -22,10 +21,8 @@ use url::Url;
 // of these only 'application/gzip' is valid according to
 // https://www.iana.org/assignments/media-types/media-types.xhtml but our own
 // Nexus uses the other two, so we cannot really complain
-lazy_static! {
-    static ref DEFAULT_ALLOWED_CONTENT_TYPES: Vec<&'static str> =
-        vec!["application/gzip", "application/tgz", "application/x-gzip"];
-}
+const DEFAULT_ALLOWED_CONTENT_TYPES: &[&str] =
+    &["application/gzip", "application/tgz", "application/x-gzip"];
 
 #[derive(Debug, Clone)]
 pub struct StackableRepoProvider {

--- a/src/provider/repository/stackablerepository.rs
+++ b/src/provider/repository/stackablerepository.rs
@@ -3,16 +3,18 @@ use std::convert::TryFrom;
 use std::fmt;
 use std::fs::File;
 use std::hash::{Hash, Hasher};
-use std::io::{copy, Cursor};
+use std::io::{copy, Cursor, Write};
 use std::path::PathBuf;
 
 use kube::api::Meta;
-use log::{debug, trace};
+use log::{debug, trace, warn};
+use reqwest::header::{ACCEPT, CONTENT_TYPE};
+use reqwest::{Client, StatusCode};
 use serde::{Deserialize, Serialize};
 use url::Url;
 
 use crate::provider::error::StackableError;
-use crate::provider::error::StackableError::PackageNotFound;
+use crate::provider::error::StackableError::{PackageDownloadError, PackageNotFound};
 use crate::provider::repository::package::Package;
 use crate::provider::repository::repository_spec::Repository;
 
@@ -112,12 +114,76 @@ impl StackableRepoProvider {
 
         let stackable_package = self.get_package(package.clone()).await?;
         let download_link = Url::parse(&stackable_package.link)?;
-        let response = reqwest::get(download_link).await?;
 
+        let client = Client::builder()
+            .build()
+            .map_err(|error| PackageDownloadError {
+                package: package.clone(),
+                download_link: download_link.clone(),
+                errormessage: format!("Unable to create http client: [{}]", error),
+            })?;
+
+        // We set the ACCEPT header field on our request which states that the only content type
+        // we are willing to accept is 'application/gzip'
+        // If the webserver is unable to provide this content type to us it _SHOULD_ respond with a
+        // 406 response code, but it seems we can't rely on that.
+        // For more details see: https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.1
+        let response = match client
+            .get(download_link.clone())
+            .header(ACCEPT, "application/gzip")
+            .send()
+            .await
+        {
+            Ok(response) if response.status().is_success() => {
+                // The request was successful, but just to be safe we'll still check the content_type
+                if let Some(content_type) = response.headers().get(CONTENT_TYPE) {
+                    if content_type == "application/gzip" {
+                        Ok(response)
+                    } else {
+                        // If we get a known wrong content type we'll abort
+                        Err(PackageDownloadError {
+                            package: package.clone(),
+                            download_link,
+                            errormessage: format!(
+                                "Got wrong 'content_type' header [{:?}] in response from webserver.",
+                                content_type
+                            ),
+                        })
+                    }
+                } else {
+                    // If we get no content_type (not sure if this is even legal) we'll soldier on and hope for the best
+                    debug!("Response had no 'content_type' header set, we'll give the sender the benefit of the doubt and try processing this anyway.");
+                    Ok(response)
+                }
+            }
+            Ok(response) if response.status() == StatusCode::NOT_ACCEPTABLE =>
+                Err(PackageDownloadError {
+                    package: package.clone(),
+                    download_link,
+                    errormessage: "Got response code 406 from webserver - Unable to negotiate content type, this is probably due to content encoding settings on the webserver.".to_string(),
+                }),
+            Ok(response) => Err(PackageDownloadError {
+                package: package.clone(),
+                download_link,
+                errormessage: format!(
+                    "Got non-success response [{}] from webserver!",
+                    response.status()
+                ),
+            }),
+            Err(error) => Err(PackageDownloadError {
+                package: package.clone(),
+                download_link,
+                errormessage: format!("{}", error),
+            }),
+        }?;
+
+        // All error cases return above, so we can safely assume that this is a valid download at
+        // this point
         let mut content = Cursor::new(response.bytes().await?);
 
         let mut out = File::create(target_path.join(package.get_file_name()))?;
         copy(&mut content, &mut out)?;
+        out.flush()?;
         Ok(())
     }
 
@@ -126,10 +192,26 @@ impl StackableRepoProvider {
 
         debug!("Retrieving repository metadata from {}", self.metadata_url);
 
-        let repo_data = reqwest::get(self.metadata_url.clone())
-            .await?
-            .json::<RepoData>()
-            .await?;
+        let repo_data = match reqwest::get(self.metadata_url.clone()).await {
+            Ok(repo_data) => repo_data,
+            Err(error) => {
+                warn!(
+                    "Failed to retrieve metadata from {} due to {:?}",
+                    self.metadata_url, error
+                );
+                return Err(error.into());
+            }
+        };
+        let repo_data = match repo_data.json::<RepoData>().await {
+            Ok(parsed_data) => parsed_data,
+            Err(error) => {
+                warn!(
+                    "Error parsing metadata from repository {}: {:?}",
+                    self.name, error
+                );
+                return Err(error.into());
+            }
+        };
 
         debug!("Got repository metadata: {:?}", repo_data);
 

--- a/src/provider/repository/stackablerepository.rs
+++ b/src/provider/repository/stackablerepository.rs
@@ -125,7 +125,6 @@ impl StackableRepoProvider {
         let download_link = Url::parse(&stackable_package.link)?;
 
         let client = Client::builder()
-            .danger_accept_invalid_certs(true)
             .build()
             .map_err(|error| PackageDownloadError {
                 package: package.clone(),


### PR DESCRIPTION
The agent currently does not delete the target directory for package installations, if the installation fails. This PR adds handling to remove those directories on errors when extracting.

The agent now also specifically requests 'application/gzip' as content type. 
We encountered issues with a webserver which provided our gzipped packages as 'application/tar' and moved the gzip to 'content_encoding' which caused reqwest to transparrently unpack the zip and the subsequent attempt by the agent to unzip this file to fail.

fixes #324 
fixes #325 

## Description

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
